### PR TITLE
Use the most specific banned import possible

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,7 @@ Pending Release
 * New release notes here
 * Don't allow installation with Flake8 3.2.0 which doesn't enable the plugin.
   This bug was fixed in Flake8 3.2.1.
+* Use the most specific message available for a banned import.
 
 1.0.3 (2016-11-05)
 ------------------

--- a/flake8_tidy_imports.py
+++ b/flake8_tidy_imports.py
@@ -109,6 +109,11 @@ class ImportChecker(object):
         else:
             return
 
+        # Sort from most to least specific paths.
+        module_names.sort(key=len, reverse=True)
+
+        warned = set()
+
         for module_name in module_names:
 
             if module_name in self.banned_modules:
@@ -116,6 +121,12 @@ class ImportChecker(object):
                     name=module_name,
                     msg=self.banned_modules[module_name]
                 )
+                if any(mod.startswith(module_name) for mod in warned):
+                    # Do not show an error for this line if we already showed
+                    # a more specific error.
+                    continue
+                else:
+                    warned.add(module_name)
                 yield (
                     node.lineno,
                     node.col_offset,

--- a/tests/test_it.py
+++ b/tests/test_it.py
@@ -194,6 +194,28 @@ def test_I201_import_mock_config():
     ]
 
 
+def test_I201_most_specific_imports():
+    errors = run_flake8(
+        """
+        import foo
+        import foo.bar
+        from foo import bar
+
+        [foo, foo.bar, bar]
+        """,
+        settings_contents="""
+        [flake8]
+        banned-modules = foo = Use foo_prime instead
+                         foo.bar = Use foo_prime.bar_rename instead
+        """
+    )
+    assert errors == [
+        "example.py:1:1: I201 Banned module 'foo' imported - Use foo_prime instead.",
+        "example.py:2:1: I201 Banned module 'foo.bar' imported - Use foo_prime.bar_rename instead.",
+        "example.py:3:1: I201 Banned module 'foo.bar' imported - Use foo_prime.bar_rename instead.",
+    ]
+
+
 def test_I201_import_mock_and_others():
     errors = run_flake8(
         """


### PR DESCRIPTION
@adamchainz This PR allows specifying a hierarchy of banned imports. The main intended use case is for handling the migration of urllib2 and urlparse via six. `urllib2` was split across 3 modules in python3 / six.moves (urllib.error and urllib), but the whole module was also removed.

So code like this is wrong, and should fail a rule:
```python
import urllib2
try:
    urllib2.urlopen('http://example.com')
except urllib2.URLError:
    pass
```
But there's not specific move we can give the end user of the rule, so we need a generic one like `use six.moves.urllib.error or six.moves.urllib.request.`

However, for code like this, we can give a better error to the end user, telling them which one :
```python
from urllib2 import URLError, urlopen
try:
    urllib2.urlopen('http://example.com')
except urllib2.URLError:
    pass
```

To give the most helpful error messages possible, this PR orders the module names longest-first, then when a rule fails only informs the user once per import. 

## Why?

This is a minor usability fix, and the old system was basically fine if the same person set up the lint rules as needs to interpret them.

I'm building a guide to upgrading large codebases to Python 3, which includes some `flake8-tidy-imports` rules for _all_ moved or removed modules I can find between Python 2 and Python 3. The primary audience for this guide is a medium-size team of software developers at my work (about 25 people), most of whom have no experience with using `six` or Python 3. The secondary audience is Python developers on the internet, for whom finding help on the error output might be difficult.

## How was this tested?

I wrote a failing test exhibiting the expected behavior, and verified that it fails as expected:
```
example.py:1:1: I201 Banned module 'urllib2' imported - Use six.moves.urllib instead.
example.py:2:1: I201 Banned module 'urllib2.URLError' imported - Use six.moves.urllib.error.URLError instead.
example.py:3:1: I201 Banned module 'urllib2' imported - Use six.moves.urllib instead.
example.py:3:1: I201 Banned module 'urllib2.URLError' imported - Use six.moves.urllib.error.URLError instead.
```

After updating rule 1201, the output is clearer, and the tests pass:
```
example.py:1:1: I201 Banned module 'urllib2' imported - Use six.moves.urllib instead.
example.py:2:1: I201 Banned module 'urllib2.URLError' imported - Use six.moves.urllib.error.URLError instead.
example.py:3:1: I201 Banned module 'urllib2.URLError' imported - Use six.moves.urllib.error.URLError instead.
```