### PR TITLE
Fix error message for banned imports

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,8 @@ Pending Release
 ---------------
 
 * New release notes here
+* Changed the error message for ``I201`` to be about the banned *import*
+  instead of *module*.
 
 1.0.4 (2017-01-12)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -43,8 +43,8 @@ to configure it in your config file, such as ``setup.cfg`` - for example:
 .. code-block:: ini
 
     [flake8]
-    banned-modules = mock = Use unittest.mock!
-                     urlparse = Use six.moves.urllib.parse!
+    banned-modules = mock = use unittest.mock!
+                     urlparse = use six.moves.urllib.parse!
 
 Rules
 -----
@@ -68,12 +68,12 @@ current), for example:
     $ flake8 file.py
     file.py:1:1: I200 Unnecessary import alias - rewrite as 'from foo import bar'.
 
-I201: Banned module 'foo' imported
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+I201: Banned import 'foo' used
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Complains about importing of banned modules. This might be useful when
+Complains about importing of banned imports. This might be useful when
 refactoring code, for example when moving from Python 2 to 3. By default there
-are no modules banned - you should configure them with ``banned-modules`` as
+are no imports banned - you should configure them with ``banned-modules`` as
 described above in 'Options'.
 
 The message includes a user-defined part that comes from the configuration. For
@@ -82,4 +82,4 @@ example:
 .. code-block:: sh
 
     $ flake8 file.py
-    file.py:1:1: I201 Banned module 'mock' imported - Use unittest.mock instead.
+    file.py:1:1: I201 Banned import 'mock' used - use unittest.mock instead.

--- a/flake8_tidy_imports.py
+++ b/flake8_tidy_imports.py
@@ -52,7 +52,7 @@ class ImportChecker(object):
             cls.banned_modules[module] = message
 
     message_I200 = "I200 Unnecessary import alias - rewrite as '{}'."
-    message_I201 = "I201 Banned module '{name}' imported - {msg}."
+    message_I201 = "I201 Banned import '{name}' used - {msg}."
 
     def run(self):
         for node in ast.walk(self.tree):

--- a/tests/test_it.py
+++ b/tests/test_it.py
@@ -170,10 +170,10 @@ def test_I201_import_mock():
 
         mock
         """,
-        ['--banned-modules', 'mock = Use unittest.mock instead']
+        ['--banned-modules', 'mock = use unittest.mock instead']
     )
     assert errors == [
-        "example.py:1:1: I201 Banned module 'mock' imported - Use unittest.mock instead."
+        "example.py:1:1: I201 Banned import 'mock' used - use unittest.mock instead."
     ]
 
 
@@ -186,11 +186,11 @@ def test_I201_import_mock_config():
         """,
         settings_contents="""
         [flake8]
-        banned-modules = mock = Use unittest.mock instead
+        banned-modules = mock = use unittest.mock instead
         """
     )
     assert errors == [
-        "example.py:1:1: I201 Banned module 'mock' imported - Use unittest.mock instead."
+        "example.py:1:1: I201 Banned import 'mock' used - use unittest.mock instead."
     ]
 
 
@@ -205,14 +205,14 @@ def test_I201_most_specific_imports():
         """,
         settings_contents="""
         [flake8]
-        banned-modules = foo = Use foo_prime instead
-                         foo.bar = Use foo_prime.bar_rename instead
+        banned-modules = foo = use foo_prime instead
+                         foo.bar = use foo_prime.bar_rename instead
         """
     )
     assert errors == [
-        "example.py:1:1: I201 Banned module 'foo' imported - Use foo_prime instead.",
-        "example.py:2:1: I201 Banned module 'foo.bar' imported - Use foo_prime.bar_rename instead.",
-        "example.py:3:1: I201 Banned module 'foo.bar' imported - Use foo_prime.bar_rename instead.",
+        "example.py:1:1: I201 Banned import 'foo' used - use foo_prime instead.",
+        "example.py:2:1: I201 Banned import 'foo.bar' used - use foo_prime.bar_rename instead.",
+        "example.py:3:1: I201 Banned import 'foo.bar' used - use foo_prime.bar_rename instead.",
     ]
 
 
@@ -224,11 +224,11 @@ def test_I201_import_mock_and_others():
 
         ast + mock
         """,
-        ['--banned-modules', 'mock = Use unittest.mock instead']
+        ['--banned-modules', 'mock = use unittest.mock instead']
     )
     assert set(errors) == {
         'example.py:1:11: E401 multiple imports on one line',
-        "example.py:1:1: I201 Banned module 'mock' imported - Use unittest.mock instead."
+        "example.py:1:1: I201 Banned import 'mock' used - use unittest.mock instead."
     }
 
 
@@ -244,8 +244,8 @@ def test_I201_import_mock_and_others_all_banned():
     )
     assert set(errors) == {
         'example.py:1:11: E401 multiple imports on one line',
-        "example.py:1:1: I201 Banned module 'mock' imported - foo.",
-        "example.py:1:1: I201 Banned module 'ast' imported - bar.",
+        "example.py:1:1: I201 Banned import 'mock' used - foo.",
+        "example.py:1:1: I201 Banned import 'ast' used - bar.",
     }
 
 
@@ -256,10 +256,10 @@ def test_I201_from_mock_import():
 
         Mock
         """,
-        ['--banned-modules', 'mock = Use unittest.mock instead']
+        ['--banned-modules', 'mock = use unittest.mock instead']
     )
     assert errors == [
-        "example.py:1:1: I201 Banned module 'mock' imported - Use unittest.mock instead."
+        "example.py:1:1: I201 Banned import 'mock' used - use unittest.mock instead."
     ]
 
 
@@ -270,10 +270,10 @@ def test_I201_from_unittest_import_mock():
 
         mock
         """,
-        ['--banned-modules', 'unittest.mock = Actually use mock']
+        ['--banned-modules', 'unittest.mock = actually use mock']
     )
     assert errors == [
-        "example.py:1:1: I201 Banned module 'unittest.mock' imported - Actually use mock."
+        "example.py:1:1: I201 Banned import 'unittest.mock' used - actually use mock."
     ]
 
 
@@ -284,8 +284,8 @@ def test_I201_from_unittest_import_mock_as():
 
         mack
         """,
-        ['--banned-modules', 'unittest.mock = Actually use mock']
+        ['--banned-modules', 'unittest.mock = actually use mock']
     )
     assert errors == [
-        "example.py:1:1: I201 Banned module 'unittest.mock' imported - Actually use mock."
+        "example.py:1:1: I201 Banned import 'unittest.mock' used - actually use mock."
     ]


### PR DESCRIPTION
Fixes #38. Technically we ban *imports* and not just *modules*, so relabel the error message as such.