### PR TITLE
Fix dot import bug

### DIFF
--- a/flake8_tidy_imports.py
+++ b/flake8_tidy_imports.py
@@ -103,9 +103,10 @@ class ImportChecker(object):
         if isinstance(node, ast.Import):
             module_names = [alias.name for alias in node.names]
         elif isinstance(node, ast.ImportFrom):
-            module_names = [node.module]
+            node_module = node.module or ''
+            module_names = [node_module]
             for alias in node.names:
-                module_names.append('{}.{}'.format(node.module, alias.name))
+                module_names.append('{}.{}'.format(node_module, alias.name))
         else:
             return
 

--- a/tests/test_it.py
+++ b/tests/test_it.py
@@ -216,6 +216,23 @@ def test_I201_most_specific_imports():
     ]
 
 
+def test_I201_relative_imports():
+    errors = run_flake8(
+        """
+        from . import foo
+        from .. import bar
+
+        foo, bar
+        """,
+        settings_contents="""
+        [flake8]
+        banned-modules = foo = use foo_prime instead
+                         bar = use bar_prime instead
+        """
+    )
+    assert errors == []
+
+
 def test_I201_import_mock_and_others():
     errors = run_flake8(
         """


### PR DESCRIPTION
@adamchainz This PR fixes a bug I introduced in #39. Apparently import statements of the form `from . import foo` get passed to the lint rule as a node with a module of `None`. This leads to `TypeError: object of type 'NoneType' has no len()` when attempting to sort the generated modules names from most to least specific.

## Testing

I added a failing test that reproduced the stack trace I saw in linting a python project. I verified that test now passes on this branch.

<hr>

Sorry to have introduced a bug that got deployed. Thanks again for your work on this library! :-)