### PR TITLE
Fix whitespace in flake8 --help output

### DIFF
--- a/flake8_tidy_imports.py
+++ b/flake8_tidy_imports.py
@@ -25,10 +25,8 @@ class ImportChecker(object):
         kwargs = {
             'action': 'store',
             'default': '',
-            'help': """
-                A map of modules to ban to the error messages to display
-                in the error.
-                """,
+            'help': "A map of modules to ban to the error messages to "
+                    "display in the error.",
         }
         if flake8.__version__.startswith('3.'):
             kwargs['parse_from_config'] = True


### PR DESCRIPTION
Before

```
$ flake8 --help | grep -A 2 banned
  --banned-modules=BANNED_MODULES
                                         A map of modules to ban to the error
                        messages to display                 in the error.
```

After

```
$ flake8 --help | grep -A 2 banned
  --banned-modules=BANNED_MODULES
                        A map of modules to ban to the error messages to
                        display in the error.
```