### PR TITLE
Fix violation code conflicts with `flake8-import-order`

### DIFF
--- a/flake8_tidy_imports.py
+++ b/flake8_tidy_imports.py
@@ -52,17 +52,17 @@ class ImportChecker(object):
             message = message.strip()
             cls.banned_modules[module] = message
 
-    message_I200 = "I200 Unnecessary import alias - rewrite as '{}'."
-    message_I201 = "I201 Banned import '{name}' used - {msg}."
+    message_I250 = "I250 Unnecessary import alias - rewrite as '{}'."
+    message_I251 = "I251 Banned import '{name}' used - {msg}."
 
     def run(self):
-        rule_funcs = (self.rule_I200, self.rule_I201)
+        rule_funcs = (self.rule_I250, self.rule_I251)
         for node in ast.walk(self.tree):
             for rule_func in rule_funcs:
                 for err in rule_func(node):
                     yield err
 
-    def rule_I200(self, node):
+    def rule_I250(self, node):
         if isinstance(node, ast.Import):
             for alias in node.names:
 
@@ -84,7 +84,7 @@ class ImportChecker(object):
                     yield (
                         node.lineno,
                         node.col_offset,
-                        self.message_I200.format(rewritten),
+                        self.message_I250.format(rewritten),
                         type(self),
                     )
         elif isinstance(node, ast.ImportFrom):
@@ -96,11 +96,11 @@ class ImportChecker(object):
                     yield (
                         node.lineno,
                         node.col_offset,
-                        self.message_I200.format(rewritten),
+                        self.message_I250.format(rewritten),
                         type(self),
                     )
 
-    def rule_I201(self, node):
+    def rule_I251(self, node):
         if isinstance(node, ast.Import):
             module_names = [alias.name for alias in node.names]
         elif isinstance(node, ast.ImportFrom):
@@ -119,7 +119,7 @@ class ImportChecker(object):
         for module_name in module_names:
 
             if module_name in self.banned_modules:
-                message = self.message_I201.format(
+                message = self.message_I251.format(
                     name=module_name,
                     msg=self.banned_modules[module_name],
                 )

--- a/test_flake8_tidy_imports.py
+++ b/test_flake8_tidy_imports.py
@@ -1,10 +1,10 @@
 # -*- encoding:utf-8 -*-
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-# I200
+# I250
 
 
-def test_I200_pass_1(flake8dir):
+def test_I250_pass_1(flake8dir):
     flake8dir.make_example_py("""
         import foo
 
@@ -14,7 +14,7 @@ def test_I200_pass_1(flake8dir):
     assert result.out_lines == []
 
 
-def test_I200_pass_2(flake8dir):
+def test_I250_pass_2(flake8dir):
     flake8dir.make_example_py("""
         import foo as foo2
 
@@ -24,7 +24,7 @@ def test_I200_pass_2(flake8dir):
     assert result.out_lines == []
 
 
-def test_I200_pass_3(flake8dir):
+def test_I250_pass_3(flake8dir):
     flake8dir.make_example_py("""
         import os.path as path2
 
@@ -34,7 +34,7 @@ def test_I200_pass_3(flake8dir):
     assert result.out_lines == []
 
 
-def test_I200_fail_1(flake8dir):
+def test_I250_fail_1(flake8dir):
     flake8dir.make_example_py("""
         import foo.bar as bar
 
@@ -42,11 +42,11 @@ def test_I200_fail_1(flake8dir):
     """)
     result = flake8dir.run_flake8()
     assert result.out_lines == [
-        "./example.py:1:1: I200 Unnecessary import alias - rewrite as 'from foo import bar'.",
+        "./example.py:1:1: I250 Unnecessary import alias - rewrite as 'from foo import bar'.",
     ]
 
 
-def test_I200_fail_2(flake8dir):
+def test_I250_fail_2(flake8dir):
     flake8dir.make_example_py("""
         import foo as foo
 
@@ -54,11 +54,11 @@ def test_I200_fail_2(flake8dir):
     """)
     result = flake8dir.run_flake8()
     assert result.out_lines == [
-        "./example.py:1:1: I200 Unnecessary import alias - rewrite as 'import foo'.",
+        "./example.py:1:1: I250 Unnecessary import alias - rewrite as 'import foo'.",
     ]
 
 
-def test_I200_fail_3(flake8dir):
+def test_I250_fail_3(flake8dir):
     flake8dir.make_example_py("""
         import foo as foo, bar as bar
 
@@ -67,13 +67,13 @@ def test_I200_fail_3(flake8dir):
     """)
     result = flake8dir.run_flake8()
     assert set(result.out_lines) == {
-        "./example.py:1:1: I200 Unnecessary import alias - rewrite as 'import foo'.",
-        "./example.py:1:1: I200 Unnecessary import alias - rewrite as 'import bar'.",
+        "./example.py:1:1: I250 Unnecessary import alias - rewrite as 'import foo'.",
+        "./example.py:1:1: I250 Unnecessary import alias - rewrite as 'import bar'.",
         "./example.py:1:18: E401 multiple imports on one line",
     }
 
 
-def test_I200_from_success_1(flake8dir):
+def test_I250_from_success_1(flake8dir):
     flake8dir.make_example_py("""
         from foo import bar as bar2
 
@@ -83,7 +83,7 @@ def test_I200_from_success_1(flake8dir):
     assert result.out_lines == []
 
 
-def test_I200_from_fail_1(flake8dir):
+def test_I250_from_fail_1(flake8dir):
     flake8dir.make_example_py("""
         from foo import bar as bar
 
@@ -92,11 +92,11 @@ def test_I200_from_fail_1(flake8dir):
     result = flake8dir.run_flake8()
 
     assert result.out_lines == [
-        "./example.py:1:1: I200 Unnecessary import alias - rewrite as 'from foo import bar'.",
+        "./example.py:1:1: I250 Unnecessary import alias - rewrite as 'from foo import bar'.",
     ]
 
 
-def test_I200_from_fail_2(flake8dir):
+def test_I250_from_fail_2(flake8dir):
     flake8dir.make_example_py("""
         from foo import bar as bar, baz as baz
 
@@ -105,15 +105,15 @@ def test_I200_from_fail_2(flake8dir):
     """)
     result = flake8dir.run_flake8()
     assert set(result.out_lines) == {
-        "./example.py:1:1: I200 Unnecessary import alias - rewrite as 'from foo import bar'.",
-        "./example.py:1:1: I200 Unnecessary import alias - rewrite as 'from foo import baz'.",
+        "./example.py:1:1: I250 Unnecessary import alias - rewrite as 'from foo import bar'.",
+        "./example.py:1:1: I250 Unnecessary import alias - rewrite as 'from foo import baz'.",
     }
 
 
-# I201
+# I251
 
 
-def test_I201_import_mock(flake8dir):
+def test_I251_import_mock(flake8dir):
     flake8dir.make_example_py("""
         import mock
 
@@ -127,7 +127,7 @@ def test_I201_import_mock(flake8dir):
     ]
 
 
-def test_I201_import_mock_config(flake8dir):
+def test_I251_import_mock_config(flake8dir):
     flake8dir.make_example_py("""
         import mock
 
@@ -139,11 +139,11 @@ def test_I201_import_mock_config(flake8dir):
     """)
     result = flake8dir.run_flake8()
     assert result.out_lines == [
-        "./example.py:1:1: I201 Banned import 'mock' used - use unittest.mock instead.",
+        "./example.py:1:1: I251 Banned import 'mock' used - use unittest.mock instead.",
     ]
 
 
-def test_I201_most_specific_imports(flake8dir):
+def test_I251_most_specific_imports(flake8dir):
     flake8dir.make_example_py("""
         import foo
         import foo.bar
@@ -158,13 +158,13 @@ def test_I201_most_specific_imports(flake8dir):
     """)
     result = flake8dir.run_flake8()
     assert result.out_lines == [
-        "./example.py:1:1: I201 Banned import 'foo' used - use foo_prime instead.",
-        "./example.py:2:1: I201 Banned import 'foo.bar' used - use foo_prime.bar_rename instead.",
-        "./example.py:3:1: I201 Banned import 'foo.bar' used - use foo_prime.bar_rename instead.",
+        "./example.py:1:1: I251 Banned import 'foo' used - use foo_prime instead.",
+        "./example.py:2:1: I251 Banned import 'foo.bar' used - use foo_prime.bar_rename instead.",
+        "./example.py:3:1: I251 Banned import 'foo.bar' used - use foo_prime.bar_rename instead.",
     ]
 
 
-def test_I201_relative_import(flake8dir):
+def test_I251_relative_import(flake8dir):
     flake8dir.make_example_py("""
         from . import foo
 
@@ -178,7 +178,7 @@ def test_I201_relative_import(flake8dir):
     assert result.out_lines == []
 
 
-def test_I201_relative_import_2(flake8dir):
+def test_I251_relative_import_2(flake8dir):
     flake8dir.make_example_py("""
         from .. import bar
 
@@ -192,7 +192,7 @@ def test_I201_relative_import_2(flake8dir):
     assert result.out_lines == []
 
 
-def test_I201_import_mock_and_others(flake8dir):
+def test_I251_import_mock_and_others(flake8dir):
     flake8dir.make_example_py("""
         import ast, mock
 
@@ -204,11 +204,11 @@ def test_I201_import_mock_and_others(flake8dir):
     )
     assert set(result.out_lines) == {
         './example.py:1:11: E401 multiple imports on one line',
-        "./example.py:1:1: I201 Banned import 'mock' used - use unittest.mock instead.",
+        "./example.py:1:1: I251 Banned import 'mock' used - use unittest.mock instead.",
     }
 
 
-def test_I201_import_mock_and_others_all_banned(flake8dir):
+def test_I251_import_mock_and_others_all_banned(flake8dir):
     flake8dir.make_example_py("""
         import ast, mock
 
@@ -220,12 +220,12 @@ def test_I201_import_mock_and_others_all_banned(flake8dir):
     )
     assert set(result.out_lines) == {
         './example.py:1:11: E401 multiple imports on one line',
-        "./example.py:1:1: I201 Banned import 'mock' used - foo.",
-        "./example.py:1:1: I201 Banned import 'ast' used - bar.",
+        "./example.py:1:1: I251 Banned import 'mock' used - foo.",
+        "./example.py:1:1: I251 Banned import 'ast' used - bar.",
     }
 
 
-def test_I201_from_mock_import(flake8dir):
+def test_I251_from_mock_import(flake8dir):
     flake8dir.make_example_py("""
         from mock import Mock
 
@@ -235,11 +235,11 @@ def test_I201_from_mock_import(flake8dir):
         extra_args=['--banned-modules', 'mock = use unittest.mock instead'],
     )
     assert result.out_lines == [
-        "./example.py:1:1: I201 Banned import 'mock' used - use unittest.mock instead.",
+        "./example.py:1:1: I251 Banned import 'mock' used - use unittest.mock instead.",
     ]
 
 
-def test_I201_from_unittest_import_mock(flake8dir):
+def test_I251_from_unittest_import_mock(flake8dir):
     flake8dir.make_example_py("""
         from unittest import mock
 
@@ -249,11 +249,11 @@ def test_I201_from_unittest_import_mock(flake8dir):
         extra_args=['--banned-modules', 'unittest.mock = actually use mock'],
     )
     assert result.out_lines == [
-        "./example.py:1:1: I201 Banned import 'unittest.mock' used - actually use mock.",
+        "./example.py:1:1: I251 Banned import 'unittest.mock' used - actually use mock.",
     ]
 
 
-def test_I201_from_unittest_import_mock_as(flake8dir):
+def test_I251_from_unittest_import_mock_as(flake8dir):
     flake8dir.make_example_py("""
         from unittest import mock as mack
 
@@ -263,11 +263,11 @@ def test_I201_from_unittest_import_mock_as(flake8dir):
         extra_args=['--banned-modules', 'unittest.mock = actually use mock'],
     )
     assert result.out_lines == [
-        "./example.py:1:1: I201 Banned import 'unittest.mock' used - actually use mock.",
+        "./example.py:1:1: I251 Banned import 'unittest.mock' used - actually use mock.",
     ]
 
 
-def test_I201_python2to3_import_md5(flake8dir):
+def test_I251_python2to3_import_md5(flake8dir):
     flake8dir.make_example_py("""
         import md5
 
@@ -277,5 +277,5 @@ def test_I201_python2to3_import_md5(flake8dir):
         extra_args=['--banned-modules', '{python2to3}'],
     )
     assert result.out_lines == [
-        "./example.py:1:1: I201 Banned import 'md5' used - removed in Python 3, use hashlib.md5() instead.",
+        "./example.py:1:1: I251 Banned import 'md5' used - removed in Python 3, use hashlib.md5() instead.",
     ]

--- a/test_flake8_tidy_imports.py
+++ b/test_flake8_tidy_imports.py
@@ -123,7 +123,7 @@ def test_I251_import_mock(flake8dir):
         extra_args=['--banned-modules', 'mock = use unittest.mock instead'],
     )
     assert result.out_lines == [
-        "./example.py:1:1: I201 Banned import 'mock' used - use unittest.mock instead.",
+        "./example.py:1:1: I251 Banned import 'mock' used - use unittest.mock instead.",
     ]
 
 


### PR DESCRIPTION
This adds 50 to the violation codes:

| OLD CODE | NEW CODE | VIOLATION |
| ------------ | ------------- | ------------ |
| I200 | I250 | Unnecessary import alias
| I200 | I251 | Banned import