### PR TITLE
Format code with Black

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,6 +8,9 @@ Flake8 Tidy Imports
 .. image:: https://img.shields.io/travis/adamchainz/flake8-tidy-imports.svg
         :target: https://travis-ci.org/adamchainz/flake8-tidy-imports
 
+.. image:: https://img.shields.io/badge/code%20style-black-000000.svg
+    :target: https://github.com/python/black
+
 A `flake8 <https://flake8.readthedocs.io/en/latest/index.html>`_ plugin that
 helps you write tidier imports.
 

--- a/flake8_tidy_imports.py
+++ b/flake8_tidy_imports.py
@@ -2,16 +2,17 @@ import ast
 
 import flake8
 
-__author__ = 'Adam Johnson'
-__email__ = 'me@adamj.eu'
-__version__ = '2.0.0'
+__author__ = "Adam Johnson"
+__email__ = "me@adamj.eu"
+__version__ = "2.0.0"
 
 
 class ImportChecker(object):
     """
     Flake8 plugin to make your import statements tidier.
     """
-    name = 'flake8-tidy-imports'
+
+    name = "flake8-tidy-imports"
     version = __version__
 
     def __init__(self, tree, *args, **kwargs):
@@ -20,31 +21,32 @@ class ImportChecker(object):
     @classmethod
     def add_options(cls, parser):
         kwargs = {
-            'action': 'store',
-            'default': '',
-            'help': "A map of modules to ban to the error messages to "
-                    "display in the error.",
+            "action": "store",
+            "default": "",
+            "help": "A map of modules to ban to the error messages to "
+            "display in the error.",
         }
-        if flake8.__version__.startswith('3.'):
-            kwargs['parse_from_config'] = True
+        if flake8.__version__.startswith("3."):
+            kwargs["parse_from_config"] = True
 
-        parser.add_option('--banned-modules', **kwargs)
+        parser.add_option("--banned-modules", **kwargs)
 
-        if flake8.__version__.startswith('2.'):
-            parser.config_options.append('banned-modules')
+        if flake8.__version__.startswith("2."):
+            parser.config_options.append("banned-modules")
 
     @classmethod
     def parse_options(cls, options):
-        lines = [line.strip() for line in options.banned_modules.split('\n')
-                 if line.strip()]
+        lines = [
+            line.strip() for line in options.banned_modules.split("\n") if line.strip()
+        ]
         cls.banned_modules = {}
         for line in lines:
-            if line == '{python2to3}':
+            if line == "{python2to3}":
                 cls.banned_modules.update(cls.python2to3_banned_modules)
                 continue
-            if '=' not in line:
+            if "=" not in line:
                 raise ValueError("'=' not found")
-            module, message = line.split('=', 1)
+            module, message = line.split("=", 1)
             module = module.strip()
             message = message.strip()
             cls.banned_modules[module] = message
@@ -63,20 +65,18 @@ class ImportChecker(object):
         if isinstance(node, ast.Import):
             for alias in node.names:
 
-                if '.' not in alias.name:
+                if "." not in alias.name:
                     from_name = None
                     imported_name = alias.name
                 else:
-                    from_name, imported_name = alias.name.rsplit('.', 1)
+                    from_name, imported_name = alias.name.rsplit(".", 1)
 
                 if imported_name == alias.asname:
 
                     if from_name:
-                        rewritten = 'from {} import {}'.format(
-                            from_name, imported_name,
-                        )
+                        rewritten = "from {} import {}".format(from_name, imported_name)
                     else:
-                        rewritten = 'import {}'.format(imported_name)
+                        rewritten = "import {}".format(imported_name)
 
                     yield (
                         node.lineno,
@@ -88,7 +88,7 @@ class ImportChecker(object):
             for alias in node.names:
                 if alias.name == alias.asname:
 
-                    rewritten = 'from {} import {}'.format(node.module, alias.name)
+                    rewritten = "from {} import {}".format(node.module, alias.name)
 
                     yield (
                         node.lineno,
@@ -101,10 +101,10 @@ class ImportChecker(object):
         if isinstance(node, ast.Import):
             module_names = [alias.name for alias in node.names]
         elif isinstance(node, ast.ImportFrom):
-            node_module = node.module or ''
+            node_module = node.module or ""
             module_names = [node_module]
             for alias in node.names:
-                module_names.append('{}.{}'.format(node_module, alias.name))
+                module_names.append("{}.{}".format(node_module, alias.name))
         else:
             return
 
@@ -117,8 +117,7 @@ class ImportChecker(object):
 
             if module_name in self.banned_modules:
                 message = self.message_I201.format(
-                    name=module_name,
-                    msg=self.banned_modules[module_name],
+                    name=module_name, msg=self.banned_modules[module_name]
                 )
                 if any(mod.startswith(module_name) for mod in warned):
                     # Do not show an error for this line if we already showed
@@ -126,249 +125,244 @@ class ImportChecker(object):
                     continue
                 else:
                     warned.add(module_name)
-                yield (
-                    node.lineno,
-                    node.col_offset,
-                    message,
-                    type(self),
-                )
+                yield (node.lineno, node.col_offset, message, type(self))
 
     python2to3_banned_modules = {
-        '__builtin__': 'use six.moves.builtins as a drop-in replacement',
-        '_winreg': 'use six.moves.winreg as a drop-in replacement',
-        'anydbm': 'use dbm as a drop-in replacement',
-        'asynchat.fifo': 'removed in Python 3',
-        'audiodev': 'removed in Python 3',
-        'BaseHTTPServer': 'use six.moves.BaseHTTPServer as a drop-in replacement',
-        'Bastion': 'removed in Python 3',
-        'bsddb185': 'use bsddb3 instead',
-        'Canvas': 'removed in Python 3',
-        'cfmfile': 'removed in Python 3',
-        'CGIHTTPServer': 'use six.moves.CGIHTTPServer as a drop-in replacement',
-        'cl': 'removed in Python 3',
-        'commands': 'removed in Python 3, use subprocess instead',
-        'compiler': 'removed in Python 3, use ast instead',
-        'ConfigParser': 'use six.moves.configparser as a drop-in replacement',
-        'contextlib.nested': 'use contextlib2.ExitStack or the shim in http://stackoverflow.com/a/39158985/303931',
-        'Cookie': 'use six.moves.http_cookies as a drop-in replacement',
-        'cookielib': 'use six.moves.http_cookiejar as a drop-in replacement',
-        'copy_reg': 'use six.moves.copyreg as a drop-in replacement',
-        'cPickle': 'use six.moves.cPickle as a drop-in replacement',
-        'cStringIO': 'removed in Python 3, use io as a drop-in replacement',
-        'cStringIO.cStringIO': 'use io.BytesIO as a drop-in replacement',
-        'cStringIO.StringIO': 'use six.moves.cStringIO as a drop-in replacement',
-        'Dialog': 'use six.moves.tkinter_dialog as a drop-in replacement',
-        'dircache': 'removed in Python 3',
-        'dl': 'removed in Python 3, use ctypes instead',
-        'DocXMLRPCServer': 'use six.moves.xmlrpc_server instead',
-        'dummy_thread': 'use six.moves._dummy_thread as a drop-in replacement',
-        'email.MIMEBase': 'use six.moves.email_mime_base as a drop-in replacement',
-        'email.MIMEMultipart': 'use six.moves.email_mime_multipart as a drop-in replacement',
-        'email.MIMENonMultipart': 'use six.moves.email_mime_nonmultipart as a drop-in replacement',
-        'email.MIMEText': 'use six.moves.email_mime_text as a drop-in replacement',
-        'FileDialog': 'use six.moves.tkinter_filedialog as a drop-in replacement',
-        'fpformat': 'removed in Python 3',
-        'ftplib.Netrc': 'removed in Python 3',
-        'gdbm': 'use six.moves.dbm_gnu as a drop-in replacement',
-        'htmlentitydefs': 'use six.moves.html_entities as a drop-in replacement',
-        'htmllib': 'use six.moves.html_parser instead',
-        'HTMLParser': 'use six.moves.html_parser as a drop-in replacement (except for HTMLParserError)',
-        'HTMLParser.HTMLParseError': 'removed in Python 3.5+',
-        'httplib': 'use six.moves.http_client as a drop-in replacement',
-        'ihooks': 'removed in Python 3',
-        'imageop': 'removed in Python 3, use PIL/Pillow instead',
-        'imputil': 'removed in Python 3',
-        'inspect.getmoduleinfo': 'moved in Python 3, use inspect.getmodulename instead',
-        'itertools.ifilter': 'use six.moves.filter as a drop-in replacement',
-        'itertools.ifilterfalse': 'use six.moves.filterfalse as a drop-in replacement',
-        'itertools.imap': 'use six.moves.map as a drop-in replacement',
-        'itertools.izip': 'use six.moves.zip as a drop-in replacement',
-        'itertools.izip_longest': 'use six.moves.zip_longest as a drop-in replacement',
-        'linuxaudiodev': 'moved in Python 3, use ossaudiodev instead',
-        'markupbase': 'moved in Python 3, use _markupbase instead',
-        'md5': 'removed in Python 3, use hashlib.md5() instead',
-        'mhlib': 'removed in Python 3, use mailbox instead',
-        'mimetools': 'moved in Python 3, use email instead',
-        'MimeWriter': 'moved in Python 3, use email instead',
-        'mimify': 'removed in Python 3, use email instead',
-        'multifile': 'removed in Python 3, use email instead',
-        'mutex': 'removed in Python 3',
-        'new': 'removed in Python 3',
-        'os.getcwd': 'use six.moves.getcwdb as a drop-in replacement',
-        'os.getcwdu': 'use six.moves.getcwd as a drop-in replacement',
-        'pipes.quote': 'use six.moves.shlex_quote as a drop-in replacement',
-        'platform._bcd2str': 'removed in Python 3',
-        'platform._mac_ver_gstalt': 'removed in Python 3',
-        'platform._mac_ver_lookup': 'removed in Python 3',
-        'plistlib.readPlist': 'moved in Python 3, use plistlib.load instead',
-        'plistlib.readPlistFromBytes': 'moved in Python 3, use plistlib.loads instead',
-        'plistlib.writePlist': 'moved in Python 3, use plistlib.dump instead',
-        'plistlib.writePlistToBytes': 'moved in Python 3, use plistlib.dumps instead',
-        'popen2': 'moved in Python 3, use subprocess instead',
-        'posixfile': 'moved in Python 3, use fcntl.lockf instead',
-        'pure': 'removed in Python 3',
-        'pydoc.Scanner': 'removed in Python 3',
-        'Queue': 'use six.moves.queue as a drop-in replacement',
-        'repr': 'use six.moves.reprlib as a drop-in replacement',
-        'rexec': 'removed in Python 3',
-        'rfc822': 'moved in Python 3, use email instead',
-        'robotparser': 'use six.moves.urllib.robotparser as a drop-in replacement',
-        'ScrolledText': 'use six.moves.tkinter_scrolledtext as a drop-in replacement',
-        'sgmllib': 'removed in Python 3',
-        'sha': 'moved in Python 3, use hashlib.sha1() instead',
-        'SimpleDialog': 'use six.moves.tkinter_simpledialog as a drop-in replacement',
-        'SimpleHTTPServer': 'use six.moves.SimpleHTTPServer as a drop-in replacement',
-        'SimpleXMLRPCServer': 'use six.moves.xmlrpc_server as a drop-in replacement',
-        'smtplib.SSLFakeFile': 'moved in Python 3, use socket.socket.makefile instead',
-        'SocketServer': 'use six.moves.socketserver as a drop-in replacement',
-        'sre': 'moved in Python 3, use re instead',
-        'statvfs': 'moved in Python 3, use os.statvfs instead',
-        'string.atof': 'moved in Python 3, use float() as a drop-in replacement',
-        'string.atoi': 'moved in Python 3. use int() as a drop-in replacement',
-        'string.atol': 'moved in Python 3. use int() as a drop-in replacement',
-        'string.capitalize': 'removed in Python 3',
-        'string.center': 'removed in Python 3',
-        'string.count': 'removed in Python 3',
-        'string.expandtabs': 'removed in Python 3',
-        'string.find': 'removed in Python 3',
-        'string.index': 'removed in Python 3',
-        'string.join': 'removed in Python 3',
-        'string.joinfields': 'removed in Python 3',
-        'string.letters': 'moved in Python 3, use string.ascii_letters as a drop-in replacement',
-        'string.ljust': 'removed in Python 3',
-        'string.lower': 'removed in Python 3',
-        'string.lowercase': 'moved in Python 3, use string.ascii_lowercase as a drop-in replacement',
-        'string.lstrip': 'removed in Python 3',
-        'string.maketrans': 'moved in Python 3, use bytes.maketrans/bytearray.maketrans or a dict of unicode codepoints to substitutions instead',  # noqa:E501
-        'string.replace': 'removed in Python 3',
-        'string.rfind': 'removed in Python 3',
-        'string.rindex': 'removed in Python 3',
-        'string.rjust': 'removed in Python 3',
-        'string.rsplit': 'removed in Python 3',
-        'string.rstrip': 'removed in Python 3',
-        'string.split': 'removed in Python 3',
-        'string.splitfields': 'removed in Python 3',
-        'string.strip': 'removed in Python 3',
-        'string.swapcase': 'removed in Python 3',
-        'string.translate': 'removed in Python 3',
-        'string.upper': 'removed in Python 3',
-        'string.uppercase': 'moved in Python 3, use string.ascii_uppercase as a drop-in replacement',
-        'string.zfill': 'removed in Python 3',
-        'StringIO': 'moved in Python 3, use io.StringIO or io.BytesIO instead',
-        'stringold': 'removed in Python 3',
-        'sunaudio': 'removed in Python 3',
-        'sv': 'removed in Python 3',
-        'tarfile.S_IFBLK': 'moved in Python 3, use stat.S_IFBLK as a drop-in replacement',
-        'tarfile.S_IFCHR': 'moved in Python 3, use stat.S_IFCHR as a drop-in replacement',
-        'tarfile.S_IFDIR': 'moved in Python 3, use stat.S_IFDIR as a drop-in replacement',
-        'tarfile.S_IFIFO': 'moved in Python 3, use stat.S_IFIFO as a drop-in replacement',
-        'tarfile.S_IFLNK': 'moved in Python 3, use stat.S_IFLNK as a drop-in replacement',
-        'tarfile.S_IFREG': 'moved in Python 3, use stat.S_IFREG as a drop-in replacement',
-        'test.test_support': 'moved in Python 3, use test.support instead',
-        'test.testall': 'removed in Python 3',
-        'thread': 'moved in Python 3, use six.moves._thread as a drop-in replacement',
-        'time.accept2dyear': 'removed in Python 3',
-        'timing': 'moved in Python 3, use time.clock instead',
-        'Tix': 'use six.moves.tkinter_tix as a drop-in replacement',
-        'tkColorChooser': 'use six.moves.tkinter_colorchooser as a drop-in replacement',
-        'tkCommonDialog': 'use six.moves.tkinter_commondialog as a drop-in replacement',
-        'Tkconstants': 'use six.moves.tkinter_constants as a drop-in replacement',
-        'Tkdnd': 'use six.moves.tkinter_dnd as a drop-in replacement',
-        'tkFileDialog': 'use six.moves.tkinter_tkfiledialog as a drop-in replacement',
-        'tkFont': 'use six.moves.tkinter_font as a drop-in replacement',
-        'Tkinter': 'use six.moves.tkinter as a drop-in replacement',
-        'tkMessageBox': 'use six.moves.tkinter_messagebox as a drop-in replacement',
-        'tkSimpleDialog': 'use six.moves.tkinter_tksimpledialog as a drop-in replacement',
-        'toaiff': 'removed in Python 3',
-        'ttk': 'use six.moves.tkinter_ttk as a drop-in replacement',
-        'types.BooleanType': 'moved in Python 3, use bool as a drop-in replacement',
-        'types.BufferType': 'removed in Python 3',
-        'types.ClassType': 'removed in Python 3',
-        'types.ComplexType': 'moved in Python 3, use complex as a drop-in replacement',
-        'types.DictionaryType': 'removed in Python 3',
-        'types.DictProxyType': 'removed in Python 3',
-        'types.DictType': 'moved in Python 3, use dict as a drop-in replacement',
-        'types.EllipsisType': 'moved in Python 3, use type(Ellipsis) as a drop-in replacement',
-        'types.FileType': 'removed in Python 3',
-        'types.FloatType': 'moved in Python 3, use float as a drop-in replacement',
-        'types.InstanceType': 'removed in Python 3',
-        'types.IntType': 'use six.integer_types as a drop-in replacement',
-        'types.ListType': 'moved in Python 3, use list as a drop-in replacement',
-        'types.LongType': 'removed in Python 3',
-        'types.NoneType': 'moved in Python 3, use type(None) as a drop-in replacement',
-        'types.NotImplementedType': 'removed in Python 3',
-        'types.ObjectType': 'removed in Python 3',
-        'types.SliceType': 'removed in Python 3',
-        'types.StringType': 'use six.binary_types or six.text_types, depending on context, instead',
-        'types.StringTypes': 'use six.string_types as a drop-in replacement',
-        'types.TupleType': 'moved in Python 3, use tuple as a drop-in replacement',
-        'types.TypeType': 'use six.class_types as a drop-in replacement',
-        'types.UnboundMethodType': 'removed in Python 3',
-        'types.UnicodeType': 'use six.text_type as a drop-in replacement',
-        'types.XRangeType': 'removed in Python 3',
-        'urllib.ContentTooShortError': 'use six.moves.urllib.error.ContentTooShortError as a drop-in replacement',
-        'urllib.FancyURLopener': 'use six.moves.urllib.request.FancyURLopener as a drop-in replacement',
-        'urllib.getproxies': 'use six.moves.urllib.request.getproxies as a drop-in replacement',
-        'urllib.pathname2url': 'use six.moves.urllib.request.pathname2url as a drop-in replacement',
-        'urllib.proxy_bypass': 'use six.moves.urllib.request.proxy_bypass as a drop-in replacement',
-        'urllib.quote': 'use six.moves.urllib.parse.quote as a drop-in replacement',
-        'urllib.quote_plus': 'use six.moves.urllib.parse.quote_plus as a drop-in replacement',
-        'urllib.splitattr': 'moved in Python 3, use urllib.parse.splitattr instead',
-        'urllib.splithost': 'moved in Python 3, use urllib.parse.splithost instead',
-        'urllib.splitnport': 'moved in Python 3, use urllib.parse.splitnport instead',
-        'urllib.splitpasswd': 'moved in Python 3, use urllib.parse.splitpasswd instead',
-        'urllib.splitport': 'moved in Python 3, use urllib.parse.splitport instead',
-        'urllib.splitquery': 'use six.moves.urllib.parse.splitquery as a drop-in replacement',
-        'urllib.splittag': 'use six.moves.urllib.parse.splittag as a drop-in replacement',
-        'urllib.splittype': 'moved in Python 3, use urllib.parse.splittype instead',
-        'urllib.splituser': 'use six.moves.urllib.parse.splituser as a drop-in replacement',
-        'urllib.splitvalue': 'moved in Python 3, use urllib.parse.splitvalue instead',
-        'urllib.unquote': 'use six.moves.urllib.parse.unquote as a drop-in replacement',
-        'urllib.unquote_plus': 'use six.moves.urllib.parse.unquote_plus as a drop-in replacement',
-        'urllib.url2pathname': 'use six.moves.urllib.request.url2pathname as a drop-in replacement',
-        'urllib.urlcleanup': 'use six.moves.urllib.request.urlcleanup as a drop-in replacement',
-        'urllib.urlencode': 'use six.moves.urllib.parse.urlencode as a drop-in replacement',
-        'urllib.URLopener': 'use six.moves.urllib.request.URLopener as a drop-in replacement',
-        'urllib.urlretrieve': 'use six.moves.urllib.request.urlretrieve as a drop-in replacement',
-        'urllib2': 'use six.moves.urllib instead',
-        'urllib2.AbstractBasicAuthHandler': 'use six.moves.urllib.request.AbstractBasicAuthHandler as a drop-in replacement',  # noqa:E501
-        'urllib2.AbstractDigestAuthHandler': 'use six.moves.urllib.request.AbstractDigestAuthHandler as a drop-in replacement',  # noqa:E501
-        'urllib2.BaseHandler': 'use six.moves.urllib.request.BaseHandler as a drop-in replacement',
-        'urllib2.build_opener': 'use six.moves.urllib.request.build_opener as a drop-in replacement',
-        'urllib2.CacheFTPHandler': 'use six.moves.urllib.request.CacheFTPHandler as a drop-in replacement',
-        'urllib2.FileHandler': 'use six.moves.urllib.request.FileHandler as a drop-in replacement',
-        'urllib2.FTPHandler': 'use six.moves.urllib.request.FTPHandler as a drop-in replacement',
-        'urllib2.HTTPBasicAuthHandler': 'use six.moves.urllib.request.HTTPBasicAuthHandler as a drop-in replacement',
-        'urllib2.HTTPCookieProcessor': 'use six.moves.urllib.request.HTTPCookieProcessor as a drop-in replacement',
-        'urllib2.HTTPDefaultErrorHandler': 'use six.moves.urllib.request.HTTPDefaultErrorHandler as a drop-in replacement',  # noqa:E501
-        'urllib2.HTTPDigestAuthHandler': 'use six.moves.urllib.request.HTTPDigestAuthHandler as a drop-in replacement',
-        'urllib2.HTTPError': 'use six.moves.urllib.error.HTTPError as a drop-in replacement',
-        'urllib2.HTTPErrorProcessor': 'use six.moves.urllib.request.HTTPErrorProcessor as a drop-in replacement',
-        'urllib2.HTTPHandler': 'use six.moves.urllib.request.HTTPHandler as a drop-in replacement',
-        'urllib2.HTTPPasswordMgr': 'use six.moves.urllib.request.HTTPPasswordMgr as a drop-in replacement',
-        'urllib2.HTTPPasswordMgrWithDefaultRealm': 'use six.moves.urllib.request.HTTPPasswordMgrWithDefaultRealm as a drop-in replacement',  # noqa:E501
-        'urllib2.HTTPRedirectHandler': 'use six.moves.urllib.request.HTTPRedirectHandler as a drop-in replacement',
-        'urllib2.HTTPSHandler': 'use six.moves.urllib.request.HTTPSHandler as a drop-in replacement',
-        'urllib2.install_opener': 'use six.moves.urllib.request.install_opener as a drop-in replacement',
-        'urllib2.OpenerDirector': 'use six.moves.urllib.request.OpenerDirector as a drop-in replacement',
-        'urllib2.ProxyBasicAuthHandler': 'use six.moves.urllib.request.ProxyBasicAuthHandler as a drop-in replacement',
-        'urllib2.ProxyDigestAuthHandler': 'use six.moves.urllib.request.ProxyDigestAuthHandler as a drop-in replacement',  # noqa:E501
-        'urllib2.ProxyHandler': 'use six.moves.urllib.request.ProxyHandler as a drop-in replacement',
-        'urllib2.quote': 'use six.moves.urllib.parse.quote as a drop-in replacement',
-        'urllib2.Request': 'use six.moves.urllib.request.Request as a drop-in replacement',
-        'urllib2.UnknownHandler': 'use six.moves.urllib.request.UnknownHandler as a drop-in replacement',
-        'urllib2.unquote': 'use six.moves.urllib.parse.unquote as a drop-in replacement',
-        'urllib2.URLError': 'use six.moves.urllib.error.URLError as a drop-in replacement',
-        'urllib2.urlopen': 'use six.moves.urllib.request.urlopen as a drop-in replacement',
-        'urlparse': 'use six.moves.urllib.parse as a drop-in replacement',
-        'urlparse.scheme_chars': 'moved in Python 3, use urllib.parse.scheme_chars',
-        'user': 'removed in Python 3',
-        'UserDict': 'moved in Python 3, use dict or collections.UserDict/collections.MutableMapping instead',
-        'UserDict.UserDict': 'moved in Python 3, use six.moves.UserDict as a drop-in replacement',
-        'UserDict.UserDictMixin': 'moved in Python 3, use collections.MutableMapping instead',
-        'UserList': 'moved in Python 3, use list or collections.UserList/collections.MutableSequence instead',
-        'UserList.UserList': 'use six.moves.UserList as a drop-in replacement',
-        'UserString': 'moved in Python 3, use six.text_type, six.binary_type or collections.UserString instead',
-        'UserString.UserString': 'use six.moves.UserString as a drop-in replacement',
-        'xmlrpclib': 'use six.moves.xmlrpc_client as a drop-in replacement',
+        "__builtin__": "use six.moves.builtins as a drop-in replacement",
+        "_winreg": "use six.moves.winreg as a drop-in replacement",
+        "anydbm": "use dbm as a drop-in replacement",
+        "asynchat.fifo": "removed in Python 3",
+        "audiodev": "removed in Python 3",
+        "BaseHTTPServer": "use six.moves.BaseHTTPServer as a drop-in replacement",
+        "Bastion": "removed in Python 3",
+        "bsddb185": "use bsddb3 instead",
+        "Canvas": "removed in Python 3",
+        "cfmfile": "removed in Python 3",
+        "CGIHTTPServer": "use six.moves.CGIHTTPServer as a drop-in replacement",
+        "cl": "removed in Python 3",
+        "commands": "removed in Python 3, use subprocess instead",
+        "compiler": "removed in Python 3, use ast instead",
+        "ConfigParser": "use six.moves.configparser as a drop-in replacement",
+        "contextlib.nested": "use contextlib2.ExitStack or the shim in http://stackoverflow.com/a/39158985/303931",  # noqa:B950
+        "Cookie": "use six.moves.http_cookies as a drop-in replacement",
+        "cookielib": "use six.moves.http_cookiejar as a drop-in replacement",
+        "copy_reg": "use six.moves.copyreg as a drop-in replacement",
+        "cPickle": "use six.moves.cPickle as a drop-in replacement",
+        "cStringIO": "removed in Python 3, use io as a drop-in replacement",
+        "cStringIO.cStringIO": "use io.BytesIO as a drop-in replacement",
+        "cStringIO.StringIO": "use six.moves.cStringIO as a drop-in replacement",
+        "Dialog": "use six.moves.tkinter_dialog as a drop-in replacement",
+        "dircache": "removed in Python 3",
+        "dl": "removed in Python 3, use ctypes instead",
+        "DocXMLRPCServer": "use six.moves.xmlrpc_server instead",
+        "dummy_thread": "use six.moves._dummy_thread as a drop-in replacement",
+        "email.MIMEBase": "use six.moves.email_mime_base as a drop-in replacement",
+        "email.MIMEMultipart": "use six.moves.email_mime_multipart as a drop-in replacement",  # noqa:B950
+        "email.MIMENonMultipart": "use six.moves.email_mime_nonmultipart as a drop-in replacement",  # noqa:B950
+        "email.MIMEText": "use six.moves.email_mime_text as a drop-in replacement",
+        "FileDialog": "use six.moves.tkinter_filedialog as a drop-in replacement",
+        "fpformat": "removed in Python 3",
+        "ftplib.Netrc": "removed in Python 3",
+        "gdbm": "use six.moves.dbm_gnu as a drop-in replacement",
+        "htmlentitydefs": "use six.moves.html_entities as a drop-in replacement",
+        "htmllib": "use six.moves.html_parser instead",
+        "HTMLParser": "use six.moves.html_parser as a drop-in replacement (except for HTMLParserError)",  # noqa:B950
+        "HTMLParser.HTMLParseError": "removed in Python 3.5+",
+        "httplib": "use six.moves.http_client as a drop-in replacement",
+        "ihooks": "removed in Python 3",
+        "imageop": "removed in Python 3, use PIL/Pillow instead",
+        "imputil": "removed in Python 3",
+        "inspect.getmoduleinfo": "moved in Python 3, use inspect.getmodulename instead",
+        "itertools.ifilter": "use six.moves.filter as a drop-in replacement",
+        "itertools.ifilterfalse": "use six.moves.filterfalse as a drop-in replacement",
+        "itertools.imap": "use six.moves.map as a drop-in replacement",
+        "itertools.izip": "use six.moves.zip as a drop-in replacement",
+        "itertools.izip_longest": "use six.moves.zip_longest as a drop-in replacement",
+        "linuxaudiodev": "moved in Python 3, use ossaudiodev instead",
+        "markupbase": "moved in Python 3, use _markupbase instead",
+        "md5": "removed in Python 3, use hashlib.md5() instead",
+        "mhlib": "removed in Python 3, use mailbox instead",
+        "mimetools": "moved in Python 3, use email instead",
+        "MimeWriter": "moved in Python 3, use email instead",
+        "mimify": "removed in Python 3, use email instead",
+        "multifile": "removed in Python 3, use email instead",
+        "mutex": "removed in Python 3",
+        "new": "removed in Python 3",
+        "os.getcwd": "use six.moves.getcwdb as a drop-in replacement",
+        "os.getcwdu": "use six.moves.getcwd as a drop-in replacement",
+        "pipes.quote": "use six.moves.shlex_quote as a drop-in replacement",
+        "platform._bcd2str": "removed in Python 3",
+        "platform._mac_ver_gstalt": "removed in Python 3",
+        "platform._mac_ver_lookup": "removed in Python 3",
+        "plistlib.readPlist": "moved in Python 3, use plistlib.load instead",
+        "plistlib.readPlistFromBytes": "moved in Python 3, use plistlib.loads instead",
+        "plistlib.writePlist": "moved in Python 3, use plistlib.dump instead",
+        "plistlib.writePlistToBytes": "moved in Python 3, use plistlib.dumps instead",
+        "popen2": "moved in Python 3, use subprocess instead",
+        "posixfile": "moved in Python 3, use fcntl.lockf instead",
+        "pure": "removed in Python 3",
+        "pydoc.Scanner": "removed in Python 3",
+        "Queue": "use six.moves.queue as a drop-in replacement",
+        "repr": "use six.moves.reprlib as a drop-in replacement",
+        "rexec": "removed in Python 3",
+        "rfc822": "moved in Python 3, use email instead",
+        "robotparser": "use six.moves.urllib.robotparser as a drop-in replacement",
+        "ScrolledText": "use six.moves.tkinter_scrolledtext as a drop-in replacement",
+        "sgmllib": "removed in Python 3",
+        "sha": "moved in Python 3, use hashlib.sha1() instead",
+        "SimpleDialog": "use six.moves.tkinter_simpledialog as a drop-in replacement",
+        "SimpleHTTPServer": "use six.moves.SimpleHTTPServer as a drop-in replacement",
+        "SimpleXMLRPCServer": "use six.moves.xmlrpc_server as a drop-in replacement",
+        "smtplib.SSLFakeFile": "moved in Python 3, use socket.socket.makefile instead",
+        "SocketServer": "use six.moves.socketserver as a drop-in replacement",
+        "sre": "moved in Python 3, use re instead",
+        "statvfs": "moved in Python 3, use os.statvfs instead",
+        "string.atof": "moved in Python 3, use float() as a drop-in replacement",
+        "string.atoi": "moved in Python 3. use int() as a drop-in replacement",
+        "string.atol": "moved in Python 3. use int() as a drop-in replacement",
+        "string.capitalize": "removed in Python 3",
+        "string.center": "removed in Python 3",
+        "string.count": "removed in Python 3",
+        "string.expandtabs": "removed in Python 3",
+        "string.find": "removed in Python 3",
+        "string.index": "removed in Python 3",
+        "string.join": "removed in Python 3",
+        "string.joinfields": "removed in Python 3",
+        "string.letters": "moved in Python 3, use string.ascii_letters as a drop-in replacement",  # noqa:B950
+        "string.ljust": "removed in Python 3",
+        "string.lower": "removed in Python 3",
+        "string.lowercase": "moved in Python 3, use string.ascii_lowercase as a drop-in replacement",  # noqa:B950
+        "string.lstrip": "removed in Python 3",
+        "string.maketrans": "moved in Python 3, use bytes.maketrans/bytearray.maketrans or a dict of unicode codepoints to substitutions instead",  # noqa:E501
+        "string.replace": "removed in Python 3",
+        "string.rfind": "removed in Python 3",
+        "string.rindex": "removed in Python 3",
+        "string.rjust": "removed in Python 3",
+        "string.rsplit": "removed in Python 3",
+        "string.rstrip": "removed in Python 3",
+        "string.split": "removed in Python 3",
+        "string.splitfields": "removed in Python 3",
+        "string.strip": "removed in Python 3",
+        "string.swapcase": "removed in Python 3",
+        "string.translate": "removed in Python 3",
+        "string.upper": "removed in Python 3",
+        "string.uppercase": "moved in Python 3, use string.ascii_uppercase as a drop-in replacement",  # noqa:B950
+        "string.zfill": "removed in Python 3",
+        "StringIO": "moved in Python 3, use io.StringIO or io.BytesIO instead",
+        "stringold": "removed in Python 3",
+        "sunaudio": "removed in Python 3",
+        "sv": "removed in Python 3",
+        "tarfile.S_IFBLK": "moved in Python 3, use stat.S_IFBLK as a drop-in replacement",  # noqa:B950
+        "tarfile.S_IFCHR": "moved in Python 3, use stat.S_IFCHR as a drop-in replacement",  # noqa:B950
+        "tarfile.S_IFDIR": "moved in Python 3, use stat.S_IFDIR as a drop-in replacement",  # noqa:B950
+        "tarfile.S_IFIFO": "moved in Python 3, use stat.S_IFIFO as a drop-in replacement",  # noqa:B950
+        "tarfile.S_IFLNK": "moved in Python 3, use stat.S_IFLNK as a drop-in replacement",  # noqa:B950
+        "tarfile.S_IFREG": "moved in Python 3, use stat.S_IFREG as a drop-in replacement",  # noqa:B950
+        "test.test_support": "moved in Python 3, use test.support instead",
+        "test.testall": "removed in Python 3",
+        "thread": "moved in Python 3, use six.moves._thread as a drop-in replacement",
+        "time.accept2dyear": "removed in Python 3",
+        "timing": "moved in Python 3, use time.clock instead",
+        "Tix": "use six.moves.tkinter_tix as a drop-in replacement",
+        "tkColorChooser": "use six.moves.tkinter_colorchooser as a drop-in replacement",
+        "tkCommonDialog": "use six.moves.tkinter_commondialog as a drop-in replacement",
+        "Tkconstants": "use six.moves.tkinter_constants as a drop-in replacement",
+        "Tkdnd": "use six.moves.tkinter_dnd as a drop-in replacement",
+        "tkFileDialog": "use six.moves.tkinter_tkfiledialog as a drop-in replacement",
+        "tkFont": "use six.moves.tkinter_font as a drop-in replacement",
+        "Tkinter": "use six.moves.tkinter as a drop-in replacement",
+        "tkMessageBox": "use six.moves.tkinter_messagebox as a drop-in replacement",
+        "tkSimpleDialog": "use six.moves.tkinter_tksimpledialog as a drop-in replacement",  # noqa:B950
+        "toaiff": "removed in Python 3",
+        "ttk": "use six.moves.tkinter_ttk as a drop-in replacement",
+        "types.BooleanType": "moved in Python 3, use bool as a drop-in replacement",
+        "types.BufferType": "removed in Python 3",
+        "types.ClassType": "removed in Python 3",
+        "types.ComplexType": "moved in Python 3, use complex as a drop-in replacement",
+        "types.DictionaryType": "removed in Python 3",
+        "types.DictProxyType": "removed in Python 3",
+        "types.DictType": "moved in Python 3, use dict as a drop-in replacement",
+        "types.EllipsisType": "moved in Python 3, use type(Ellipsis) as a drop-in replacement",  # noqa:B950
+        "types.FileType": "removed in Python 3",
+        "types.FloatType": "moved in Python 3, use float as a drop-in replacement",
+        "types.InstanceType": "removed in Python 3",
+        "types.IntType": "use six.integer_types as a drop-in replacement",
+        "types.ListType": "moved in Python 3, use list as a drop-in replacement",
+        "types.LongType": "removed in Python 3",
+        "types.NoneType": "moved in Python 3, use type(None) as a drop-in replacement",
+        "types.NotImplementedType": "removed in Python 3",
+        "types.ObjectType": "removed in Python 3",
+        "types.SliceType": "removed in Python 3",
+        "types.StringType": "use six.binary_types or six.text_types, depending on context, instead",  # noqa:B950
+        "types.StringTypes": "use six.string_types as a drop-in replacement",
+        "types.TupleType": "moved in Python 3, use tuple as a drop-in replacement",
+        "types.TypeType": "use six.class_types as a drop-in replacement",
+        "types.UnboundMethodType": "removed in Python 3",
+        "types.UnicodeType": "use six.text_type as a drop-in replacement",
+        "types.XRangeType": "removed in Python 3",
+        "urllib.ContentTooShortError": "use six.moves.urllib.error.ContentTooShortError as a drop-in replacement",  # noqa:B950
+        "urllib.FancyURLopener": "use six.moves.urllib.request.FancyURLopener as a drop-in replacement",  # noqa:B950
+        "urllib.getproxies": "use six.moves.urllib.request.getproxies as a drop-in replacement",  # noqa:B950
+        "urllib.pathname2url": "use six.moves.urllib.request.pathname2url as a drop-in replacement",  # noqa:B950
+        "urllib.proxy_bypass": "use six.moves.urllib.request.proxy_bypass as a drop-in replacement",  # noqa:B950
+        "urllib.quote": "use six.moves.urllib.parse.quote as a drop-in replacement",
+        "urllib.quote_plus": "use six.moves.urllib.parse.quote_plus as a drop-in replacement",  # noqa:B950
+        "urllib.splitattr": "moved in Python 3, use urllib.parse.splitattr instead",
+        "urllib.splithost": "moved in Python 3, use urllib.parse.splithost instead",
+        "urllib.splitnport": "moved in Python 3, use urllib.parse.splitnport instead",
+        "urllib.splitpasswd": "moved in Python 3, use urllib.parse.splitpasswd instead",
+        "urllib.splitport": "moved in Python 3, use urllib.parse.splitport instead",
+        "urllib.splitquery": "use six.moves.urllib.parse.splitquery as a drop-in replacement",  # noqa:B950
+        "urllib.splittag": "use six.moves.urllib.parse.splittag as a drop-in replacement",  # noqa:B950
+        "urllib.splittype": "moved in Python 3, use urllib.parse.splittype instead",
+        "urllib.splituser": "use six.moves.urllib.parse.splituser as a drop-in replacement",  # noqa:B950
+        "urllib.splitvalue": "moved in Python 3, use urllib.parse.splitvalue instead",
+        "urllib.unquote": "use six.moves.urllib.parse.unquote as a drop-in replacement",
+        "urllib.unquote_plus": "use six.moves.urllib.parse.unquote_plus as a drop-in replacement",  # noqa:B950
+        "urllib.url2pathname": "use six.moves.urllib.request.url2pathname as a drop-in replacement",  # noqa:B950
+        "urllib.urlcleanup": "use six.moves.urllib.request.urlcleanup as a drop-in replacement",  # noqa:B950
+        "urllib.urlencode": "use six.moves.urllib.parse.urlencode as a drop-in replacement",  # noqa:B950
+        "urllib.URLopener": "use six.moves.urllib.request.URLopener as a drop-in replacement",  # noqa:B950
+        "urllib.urlretrieve": "use six.moves.urllib.request.urlretrieve as a drop-in replacement",  # noqa:B950
+        "urllib2": "use six.moves.urllib instead",
+        "urllib2.AbstractBasicAuthHandler": "use six.moves.urllib.request.AbstractBasicAuthHandler as a drop-in replacement",  # noqa:B950
+        "urllib2.AbstractDigestAuthHandler": "use six.moves.urllib.request.AbstractDigestAuthHandler as a drop-in replacement",  # noqa:B950
+        "urllib2.BaseHandler": "use six.moves.urllib.request.BaseHandler as a drop-in replacement",  # noqa:B950
+        "urllib2.build_opener": "use six.moves.urllib.request.build_opener as a drop-in replacement",  # noqa:B950
+        "urllib2.CacheFTPHandler": "use six.moves.urllib.request.CacheFTPHandler as a drop-in replacement",  # noqa:B950
+        "urllib2.FileHandler": "use six.moves.urllib.request.FileHandler as a drop-in replacement",  # noqa:B950
+        "urllib2.FTPHandler": "use six.moves.urllib.request.FTPHandler as a drop-in replacement",  # noqa:B950
+        "urllib2.HTTPBasicAuthHandler": "use six.moves.urllib.request.HTTPBasicAuthHandler as a drop-in replacement",  # noqa:B950
+        "urllib2.HTTPCookieProcessor": "use six.moves.urllib.request.HTTPCookieProcessor as a drop-in replacement",  # noqa:B950
+        "urllib2.HTTPDefaultErrorHandler": "use six.moves.urllib.request.HTTPDefaultErrorHandler as a drop-in replacement",  # noqa:B950
+        "urllib2.HTTPDigestAuthHandler": "use six.moves.urllib.request.HTTPDigestAuthHandler as a drop-in replacement",  # noqa:B950
+        "urllib2.HTTPError": "use six.moves.urllib.error.HTTPError as a drop-in replacement",  # noqa:B950
+        "urllib2.HTTPErrorProcessor": "use six.moves.urllib.request.HTTPErrorProcessor as a drop-in replacement",  # noqa:B950
+        "urllib2.HTTPHandler": "use six.moves.urllib.request.HTTPHandler as a drop-in replacement",  # noqa:B950
+        "urllib2.HTTPPasswordMgr": "use six.moves.urllib.request.HTTPPasswordMgr as a drop-in replacement",  # noqa:B950
+        "urllib2.HTTPPasswordMgrWithDefaultRealm": "use six.moves.urllib.request.HTTPPasswordMgrWithDefaultRealm as a drop-in replacement",  # noqa:B950
+        "urllib2.HTTPRedirectHandler": "use six.moves.urllib.request.HTTPRedirectHandler as a drop-in replacement",  # noqa:B950
+        "urllib2.HTTPSHandler": "use six.moves.urllib.request.HTTPSHandler as a drop-in replacement",  # noqa:B950
+        "urllib2.install_opener": "use six.moves.urllib.request.install_opener as a drop-in replacement",  # noqa:B950
+        "urllib2.OpenerDirector": "use six.moves.urllib.request.OpenerDirector as a drop-in replacement",  # noqa:B950
+        "urllib2.ProxyBasicAuthHandler": "use six.moves.urllib.request.ProxyBasicAuthHandler as a drop-in replacement",  # noqa:B950
+        "urllib2.ProxyDigestAuthHandler": "use six.moves.urllib.request.ProxyDigestAuthHandler as a drop-in replacement",  # noqa:B950
+        "urllib2.ProxyHandler": "use six.moves.urllib.request.ProxyHandler as a drop-in replacement",  # noqa:B950
+        "urllib2.quote": "use six.moves.urllib.parse.quote as a drop-in replacement",
+        "urllib2.Request": "use six.moves.urllib.request.Request as a drop-in replacement",  # noqa:B950
+        "urllib2.UnknownHandler": "use six.moves.urllib.request.UnknownHandler as a drop-in replacement",  # noqa:B950
+        "urllib2.unquote": "use six.moves.urllib.parse.unquote as a drop-in replacement",  # noqa:B950
+        "urllib2.URLError": "use six.moves.urllib.error.URLError as a drop-in replacement",  # noqa:B950
+        "urllib2.urlopen": "use six.moves.urllib.request.urlopen as a drop-in replacement",  # noqa:B950
+        "urlparse": "use six.moves.urllib.parse as a drop-in replacement",
+        "urlparse.scheme_chars": "moved in Python 3, use urllib.parse.scheme_chars",
+        "user": "removed in Python 3",
+        "UserDict": "moved in Python 3, use dict or collections.UserDict/collections.MutableMapping instead",  # noqa:B950
+        "UserDict.UserDict": "moved in Python 3, use six.moves.UserDict as a drop-in replacement",  # noqa:B950
+        "UserDict.UserDictMixin": "moved in Python 3, use collections.MutableMapping instead",  # noqa:B950
+        "UserList": "moved in Python 3, use list or collections.UserList/collections.MutableSequence instead",  # noqa:B950
+        "UserList.UserList": "use six.moves.UserList as a drop-in replacement",
+        "UserString": "moved in Python 3, use six.text_type, six.binary_type or collections.UserString instead",  # noqa:B950
+        "UserString.UserString": "use six.moves.UserString as a drop-in replacement",
+        "xmlrpclib": "use six.moves.xmlrpc_client as a drop-in replacement",
     }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+target-version = ['py35']

--- a/requirements/py35.txt
+++ b/requirements/py35.txt
@@ -11,7 +11,7 @@ atomicwrites==1.3.0 \
 attrs==19.1.0 \
     --hash=sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79 \
     --hash=sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399 \
-    # via pytest
+    # via flake8-bugbear, pytest
 bleach==3.1.0 \
     --hash=sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16 \
     --hash=sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa \
@@ -32,9 +32,9 @@ entrypoints==0.3 \
     --hash=sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19 \
     --hash=sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451 \
     # via flake8
-flake8-commas==2.0.0 \
-    --hash=sha256:d3005899466f51380387df7151fb59afec666a0f4f4a2c6a8995b975de0f44b7 \
-    --hash=sha256:ee2141a3495ef9789a3894ed8802d03eff1eaaf98ce6d8653a7c573ef101935e
+flake8-bugbear==19.3.0 \
+    --hash=sha256:5070774b668be92c4312e5ca82748ddf4ecaa7a24ff062662681bb745c7896eb \
+    --hash=sha256:fef9c9826d14ec23187ae1edeb3c6513c4e46bf0e70d86bac38f7d9aabae113d
 flake8==3.7.7 \
     --hash=sha256:859996073f341f2670741b51ec1e67a01da142831aa1fdc6242dbf88dffbe661 \
     --hash=sha256:a796a115208f5c03b18f332f7c11729812c8c3ded6c46319c59b53efd3819da8

--- a/requirements/py36.txt
+++ b/requirements/py36.txt
@@ -11,7 +11,7 @@ atomicwrites==1.3.0 \
 attrs==19.1.0 \
     --hash=sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79 \
     --hash=sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399 \
-    # via pytest
+    # via flake8-bugbear, pytest
 bleach==3.1.0 \
     --hash=sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16 \
     --hash=sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa \
@@ -32,9 +32,9 @@ entrypoints==0.3 \
     --hash=sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19 \
     --hash=sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451 \
     # via flake8
-flake8-commas==2.0.0 \
-    --hash=sha256:d3005899466f51380387df7151fb59afec666a0f4f4a2c6a8995b975de0f44b7 \
-    --hash=sha256:ee2141a3495ef9789a3894ed8802d03eff1eaaf98ce6d8653a7c573ef101935e
+flake8-bugbear==19.3.0 \
+    --hash=sha256:5070774b668be92c4312e5ca82748ddf4ecaa7a24ff062662681bb745c7896eb \
+    --hash=sha256:fef9c9826d14ec23187ae1edeb3c6513c4e46bf0e70d86bac38f7d9aabae113d
 flake8==3.7.7 \
     --hash=sha256:859996073f341f2670741b51ec1e67a01da142831aa1fdc6242dbf88dffbe661 \
     --hash=sha256:a796a115208f5c03b18f332f7c11729812c8c3ded6c46319c59b53efd3819da8

--- a/requirements/py37.txt
+++ b/requirements/py37.txt
@@ -4,6 +4,10 @@
 #
 #    ./compile.sh
 #
+appdirs==1.4.3 \
+    --hash=sha256:9e5896d1372858f8dd3344faf4e5014d21849c756c8d5701f78f8a103b372d92 \
+    --hash=sha256:d8b24664561d0d34ddfaec54636d502d7cea6e29c3eaf68f3df6180863e2166e \
+    # via black
 atomicwrites==1.3.0 \
     --hash=sha256:03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4 \
     --hash=sha256:75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6 \
@@ -11,7 +15,10 @@ atomicwrites==1.3.0 \
 attrs==19.1.0 \
     --hash=sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79 \
     --hash=sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399 \
-    # via pytest
+    # via black, flake8-bugbear, pytest
+black==19.3b0 ; python_version == "3.7.*" \
+    --hash=sha256:09a9dcb7c46ed496a9850b76e4e825d6049ecd38b611f1224857a79bd985a8cf \
+    --hash=sha256:68950ffd4d9169716bcb8719a56c07a2f4485354fec061cdd5910aa07369731c
 bleach==3.1.0 \
     --hash=sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16 \
     --hash=sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa \
@@ -24,6 +31,10 @@ chardet==3.0.4 \
     --hash=sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae \
     --hash=sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691 \
     # via requests
+click==7.0 \
+    --hash=sha256:2335065e6395b9e67ca716de5f7526736bfa6ceead690adf616d925bdc622b13 \
+    --hash=sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7 \
+    # via black
 docutils==0.14 \
     --hash=sha256:02aec4bd92ab067f6ff27a38a38a41173bf01bed8f89157768c1573f53e474a6 \
     --hash=sha256:51e64ef2ebfb29cae1faa133b3710143496eca21c530f3f71424d77687764274 \
@@ -32,9 +43,9 @@ entrypoints==0.3 \
     --hash=sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19 \
     --hash=sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451 \
     # via flake8
-flake8-commas==2.0.0 \
-    --hash=sha256:d3005899466f51380387df7151fb59afec666a0f4f4a2c6a8995b975de0f44b7 \
-    --hash=sha256:ee2141a3495ef9789a3894ed8802d03eff1eaaf98ce6d8653a7c573ef101935e
+flake8-bugbear==19.3.0 \
+    --hash=sha256:5070774b668be92c4312e5ca82748ddf4ecaa7a24ff062662681bb745c7896eb \
+    --hash=sha256:fef9c9826d14ec23187ae1edeb3c6513c4e46bf0e70d86bac38f7d9aabae113d
 flake8==3.7.7 \
     --hash=sha256:859996073f341f2670741b51ec1e67a01da142831aa1fdc6242dbf88dffbe661 \
     --hash=sha256:a796a115208f5c03b18f332f7c11729812c8c3ded6c46319c59b53efd3819da8
@@ -115,6 +126,10 @@ six==1.12.0 \
     --hash=sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c \
     --hash=sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73 \
     # via bleach, packaging, pytest, readme-renderer
+toml==0.10.0 \
+    --hash=sha256:229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c \
+    --hash=sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e \
+    # via black
 tqdm==4.32.1 \
     --hash=sha256:0a860bf2683fdbb4812fe539a6c22ea3f1777843ea985cb8c3807db448a0f7ab \
     --hash=sha256:e288416eecd4df19d12407d0c913cbf77aa8009d7fddb18f632aded3bdbdda6b \

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -1,6 +1,7 @@
+black ; python_version == '3.7.*'
 docutils
 flake8
-flake8-commas
+flake8-bugbear
 isort
 multilint
 pathlib

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,11 +1,16 @@
 [flake8]
-max_line_length = 120
+max-line-length = 80
+select = C,E,F,W,B,B950
+ignore = E501,W503
 
 [isort]
 include_trailing_comma = True
-line_length = 120
-multi_line_output = 5
+force_grid_wrap = 0
+known_first_party = apig_wsgi
+line_length = 88
+multi_line_output = 3
 not_skip = __init__.py
+use_parentheses = True
 
 [metadata]
 license_file = LICENSE

--- a/setup.py
+++ b/setup.py
@@ -4,52 +4,45 @@ from setuptools import setup
 
 
 def get_version(filename):
-    with open(filename, 'r') as fp:
+    with open(filename, "r") as fp:
         contents = fp.read()
     return re.search(r"__version__ = ['\"]([^'\"]+)['\"]", contents).group(1)
 
 
-version = get_version('flake8_tidy_imports.py')
+version = get_version("flake8_tidy_imports.py")
 
-with open('README.rst', 'r') as readme_file:
+with open("README.rst", "r") as readme_file:
     readme = readme_file.read()
 
-with open('HISTORY.rst', 'r') as history_file:
+with open("HISTORY.rst", "r") as history_file:
     history = history_file.read()
 
 setup(
-    name='flake8-tidy-imports',
+    name="flake8-tidy-imports",
     version=version,
     description="A flake8 plugin that helps you write tidier imports.",
-    long_description=readme + '\n\n' + history,
+    long_description=readme + "\n\n" + history,
     author="Adam Johnson",
-    author_email='me@adamj.eu',
-    url='https://github.com/adamchainz/flake8-tidy-imports',
-    entry_points={
-        'flake8.extension': [
-            'I20 = '
-            'flake8_tidy_imports:ImportChecker',
-        ],
-    },
-    py_modules=['flake8_tidy_imports'],
+    author_email="me@adamj.eu",
+    url="https://github.com/adamchainz/flake8-tidy-imports",
+    entry_points={"flake8.extension": ["I20 = " "flake8_tidy_imports:ImportChecker"]},
+    py_modules=["flake8_tidy_imports"],
     include_package_data=True,
-    install_requires=[
-        'flake8!=3.2.0',
-    ],
-    python_requires='>=3.5',
+    install_requires=["flake8!=3.2.0"],
+    python_requires=">=3.5",
     license="ISCL",
     zip_safe=False,
-    keywords='flake8_tidy_imports',
+    keywords="flake8_tidy_imports",
     classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'Framework :: Flake8',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: ISC License (ISCL)',
-        'Natural Language :: English',
-        'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
+        "Development Status :: 5 - Production/Stable",
+        "Framework :: Flake8",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: ISC License (ISCL)",
+        "Natural Language :: English",
+        "Programming Language :: Python :: 3 :: Only",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
     ],
 )

--- a/test_flake8_tidy_imports.py
+++ b/test_flake8_tidy_imports.py
@@ -2,66 +2,81 @@
 
 
 def test_I200_pass_1(flake8dir):
-    flake8dir.make_example_py("""
+    flake8dir.make_example_py(
+        """
         import foo
 
         foo
-    """)
+    """
+    )
     result = flake8dir.run_flake8()
     assert result.out_lines == []
 
 
 def test_I200_pass_2(flake8dir):
-    flake8dir.make_example_py("""
+    flake8dir.make_example_py(
+        """
         import foo as foo2
 
         foo2
-    """)
+    """
+    )
     result = flake8dir.run_flake8()
     assert result.out_lines == []
 
 
 def test_I200_pass_3(flake8dir):
-    flake8dir.make_example_py("""
+    flake8dir.make_example_py(
+        """
         import os.path as path2
 
         path2
-    """)
+    """
+    )
     result = flake8dir.run_flake8()
     assert result.out_lines == []
 
 
 def test_I200_fail_1(flake8dir):
-    flake8dir.make_example_py("""
+    flake8dir.make_example_py(
+        """
         import foo.bar as bar
 
         bar
-    """)
+    """
+    )
     result = flake8dir.run_flake8()
     assert result.out_lines == [
-        "./example.py:1:1: I200 Unnecessary import alias - rewrite as 'from foo import bar'.",
+        (
+            "./example.py:1:1: I200 Unnecessary import alias - rewrite as "
+            + "'from foo import bar'."
+        )
     ]
 
 
 def test_I200_fail_2(flake8dir):
-    flake8dir.make_example_py("""
+    flake8dir.make_example_py(
+        """
         import foo as foo
 
         foo
-    """)
+    """
+    )
     result = flake8dir.run_flake8()
     assert result.out_lines == [
-        "./example.py:1:1: I200 Unnecessary import alias - rewrite as 'import foo'.",
+        "./example.py:1:1: I200 Unnecessary import alias - rewrite as 'import foo'."
     ]
 
 
 def test_I200_fail_3(flake8dir):
-    flake8dir.make_example_py("""
+    flake8dir.make_example_py(
+        """
         import foo as foo, bar as bar
 
         foo
         bar
-    """)
+    """
+    )
     result = flake8dir.run_flake8()
     assert set(result.out_lines) == {
         "./example.py:1:1: I200 Unnecessary import alias - rewrite as 'import foo'.",
@@ -71,39 +86,54 @@ def test_I200_fail_3(flake8dir):
 
 
 def test_I200_from_success_1(flake8dir):
-    flake8dir.make_example_py("""
+    flake8dir.make_example_py(
+        """
         from foo import bar as bar2
 
         bar2
-    """)
+    """
+    )
     result = flake8dir.run_flake8()
     assert result.out_lines == []
 
 
 def test_I200_from_fail_1(flake8dir):
-    flake8dir.make_example_py("""
+    flake8dir.make_example_py(
+        """
         from foo import bar as bar
 
         bar
-    """)
+    """
+    )
     result = flake8dir.run_flake8()
 
     assert result.out_lines == [
-        "./example.py:1:1: I200 Unnecessary import alias - rewrite as 'from foo import bar'.",
+        (
+            "./example.py:1:1: I200 Unnecessary import alias - rewrite as "
+            + "'from foo import bar'."
+        )
     ]
 
 
 def test_I200_from_fail_2(flake8dir):
-    flake8dir.make_example_py("""
+    flake8dir.make_example_py(
+        """
         from foo import bar as bar, baz as baz
 
         bar
         baz
-    """)
+    """
+    )
     result = flake8dir.run_flake8()
     assert set(result.out_lines) == {
-        "./example.py:1:1: I200 Unnecessary import alias - rewrite as 'from foo import bar'.",
-        "./example.py:1:1: I200 Unnecessary import alias - rewrite as 'from foo import baz'.",
+        (
+            "./example.py:1:1: I200 Unnecessary import alias - rewrite as "
+            + "'from foo import bar'."
+        ),
+        (
+            "./example.py:1:1: I200 Unnecessary import alias - rewrite as "
+            + "'from foo import baz'."
+        ),
     }
 
 
@@ -111,168 +141,203 @@ def test_I200_from_fail_2(flake8dir):
 
 
 def test_I201_import_mock(flake8dir):
-    flake8dir.make_example_py("""
+    flake8dir.make_example_py(
+        """
         import mock
 
         mock
-    """)
+    """
+    )
     result = flake8dir.run_flake8(
-        extra_args=['--banned-modules', 'mock = use unittest.mock instead'],
+        extra_args=["--banned-modules", "mock = use unittest.mock instead"]
     )
     assert result.out_lines == [
-        "./example.py:1:1: I201 Banned import 'mock' used - use unittest.mock instead.",
+        "./example.py:1:1: I201 Banned import 'mock' used - use unittest.mock instead."
     ]
 
 
 def test_I201_import_mock_config(flake8dir):
-    flake8dir.make_example_py("""
+    flake8dir.make_example_py(
+        """
         import mock
 
         mock
-    """)
-    flake8dir.make_setup_cfg("""
+    """
+    )
+    flake8dir.make_setup_cfg(
+        """
         [flake8]
         banned-modules = mock = use unittest.mock instead
-    """)
+    """
+    )
     result = flake8dir.run_flake8()
     assert result.out_lines == [
-        "./example.py:1:1: I201 Banned import 'mock' used - use unittest.mock instead.",
+        "./example.py:1:1: I201 Banned import 'mock' used - use unittest.mock instead."
     ]
 
 
 def test_I201_most_specific_imports(flake8dir):
-    flake8dir.make_example_py("""
+    flake8dir.make_example_py(
+        """
         import foo
         import foo.bar
         from foo import bar
 
         [foo, foo.bar, bar]
-    """)
-    flake8dir.make_setup_cfg("""
+    """
+    )
+    flake8dir.make_setup_cfg(
+        """
         [flake8]
         banned-modules = foo = use foo_prime instead
                          foo.bar = use foo_prime.bar_rename instead
-    """)
+    """
+    )
     result = flake8dir.run_flake8()
     assert result.out_lines == [
         "./example.py:1:1: I201 Banned import 'foo' used - use foo_prime instead.",
-        "./example.py:2:1: I201 Banned import 'foo.bar' used - use foo_prime.bar_rename instead.",
-        "./example.py:3:1: I201 Banned import 'foo.bar' used - use foo_prime.bar_rename instead.",
+        (
+            "./example.py:2:1: I201 Banned import 'foo.bar' used - use "
+            + "foo_prime.bar_rename instead."
+        ),
+        (
+            "./example.py:3:1: I201 Banned import 'foo.bar' used - use "
+            + "foo_prime.bar_rename instead."
+        ),
     ]
 
 
 def test_I201_relative_import(flake8dir):
-    flake8dir.make_example_py("""
+    flake8dir.make_example_py(
+        """
         from . import foo
 
         foo
-    """)
-    flake8dir.make_setup_cfg("""
+    """
+    )
+    flake8dir.make_setup_cfg(
+        """
         [flake8]
         banned-modules = bar = use bar_prime instead
-    """)
+    """
+    )
     result = flake8dir.run_flake8()
     assert result.out_lines == []
 
 
 def test_I201_relative_import_2(flake8dir):
-    flake8dir.make_example_py("""
+    flake8dir.make_example_py(
+        """
         from .. import bar
 
         bar
-    """)
-    flake8dir.make_setup_cfg("""
+    """
+    )
+    flake8dir.make_setup_cfg(
+        """
         [flake8]
         banned-modules = bar = use bar_prime instead
-    """)
+    """
+    )
     result = flake8dir.run_flake8()
     assert result.out_lines == []
 
 
 def test_I201_import_mock_and_others(flake8dir):
-    flake8dir.make_example_py("""
+    flake8dir.make_example_py(
+        """
         import ast, mock
 
 
         ast + mock
-    """)
+    """
+    )
     result = flake8dir.run_flake8(
-        extra_args=['--banned-modules', 'mock = use unittest.mock instead'],
+        extra_args=["--banned-modules", "mock = use unittest.mock instead"]
     )
     assert set(result.out_lines) == {
-        './example.py:1:11: E401 multiple imports on one line',
+        "./example.py:1:11: E401 multiple imports on one line",
         "./example.py:1:1: I201 Banned import 'mock' used - use unittest.mock instead.",
     }
 
 
 def test_I201_import_mock_and_others_all_banned(flake8dir):
-    flake8dir.make_example_py("""
+    flake8dir.make_example_py(
+        """
         import ast, mock
 
 
         ast + mock
-    """)
+    """
+    )
     result = flake8dir.run_flake8(
-        extra_args=['--banned-modules', 'mock = foo\nast = bar'],
+        extra_args=["--banned-modules", "mock = foo\nast = bar"]
     )
     assert set(result.out_lines) == {
-        './example.py:1:11: E401 multiple imports on one line',
+        "./example.py:1:11: E401 multiple imports on one line",
         "./example.py:1:1: I201 Banned import 'mock' used - foo.",
         "./example.py:1:1: I201 Banned import 'ast' used - bar.",
     }
 
 
 def test_I201_from_mock_import(flake8dir):
-    flake8dir.make_example_py("""
+    flake8dir.make_example_py(
+        """
         from mock import Mock
 
         Mock
-    """)
+    """
+    )
     result = flake8dir.run_flake8(
-        extra_args=['--banned-modules', 'mock = use unittest.mock instead'],
+        extra_args=["--banned-modules", "mock = use unittest.mock instead"]
     )
     assert result.out_lines == [
-        "./example.py:1:1: I201 Banned import 'mock' used - use unittest.mock instead.",
+        "./example.py:1:1: I201 Banned import 'mock' used - use unittest.mock instead."
     ]
 
 
 def test_I201_from_unittest_import_mock(flake8dir):
-    flake8dir.make_example_py("""
+    flake8dir.make_example_py(
+        """
         from unittest import mock
 
         mock
-    """)
+    """
+    )
     result = flake8dir.run_flake8(
-        extra_args=['--banned-modules', 'unittest.mock = actually use mock'],
+        extra_args=["--banned-modules", "unittest.mock = actually use mock"]
     )
     assert result.out_lines == [
-        "./example.py:1:1: I201 Banned import 'unittest.mock' used - actually use mock.",
+        "./example.py:1:1: I201 Banned import 'unittest.mock' used - actually use mock."
     ]
 
 
 def test_I201_from_unittest_import_mock_as(flake8dir):
-    flake8dir.make_example_py("""
+    flake8dir.make_example_py(
+        """
         from unittest import mock as mack
 
         mack
-    """)
+    """
+    )
     result = flake8dir.run_flake8(
-        extra_args=['--banned-modules', 'unittest.mock = actually use mock'],
+        extra_args=["--banned-modules", "unittest.mock = actually use mock"]
     )
     assert result.out_lines == [
-        "./example.py:1:1: I201 Banned import 'unittest.mock' used - actually use mock.",
+        "./example.py:1:1: I201 Banned import 'unittest.mock' used - actually use mock."
     ]
 
 
 def test_I201_python2to3_import_md5(flake8dir):
-    flake8dir.make_example_py("""
+    flake8dir.make_example_py(
+        """
         import md5
 
         md5
-    """)
-    result = flake8dir.run_flake8(
-        extra_args=['--banned-modules', '{python2to3}'],
+    """
     )
+    result = flake8dir.run_flake8(extra_args=["--banned-modules", "{python2to3}"])
     assert result.out_lines == [
-        "./example.py:1:1: I201 Banned import 'md5' used - removed in Python 3, use hashlib.md5() instead.",
+        "./example.py:1:1: I201 Banned import 'md5' used - removed in Python "
+        + "3, use hashlib.md5() instead."
     ]


### PR DESCRIPTION
* Add black and flake8-bugbear - automatically picked up by multilint
* Add pyproject.toml black configuration to target Python 3.5
* Reconfigure isort and flake8
* Drop flake8-commas and rely on Black's trailing comma insertion only
* Run black on the code
* Add README badge