### PR TITLE
Switch 'pip install' for 'python -m pip install'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,6 @@ matrix:
   - python: 3.8
   - python: 3.9-dev
 
-install: pip install tox-travis
+install: python -m pip install tox-travis
 
 script: tox

--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ Install from ``pip`` with:
 
 .. code-block:: sh
 
-     pip install flake8-tidy-imports
+     python -m pip install flake8-tidy-imports
 
 Python 3.5 to 3.8 supported.
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist =
     py38-codestyle
 
 [testenv]
-install_command = pip install --no-deps {opts} {packages}
+install_command = python -m pip install --no-deps {opts} {packages}
 commands = pytest {posargs}
 
 [testenv:py35]


### PR DESCRIPTION
As per [Brett Cannon's article](https://snarky.ca/why-you-should-use-python-m-pip/).