### PR TITLE
Add option to allow relative imports up to a certain level

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -144,6 +144,13 @@ Absolute imports are recommended by `PEP8 <https://www.python.org/dev/peps/pep-0
 
     Absolute imports are recommended, as they are usually more readable and tend to be better behaved...
 
+To allow some relative imports up to a certain backwards level, set the ``max-relative-import-levels`` option to the maximum number of consecutive dots to allow. For example, with ``max-relative-import-level = 1``:
+
+* ``from . import bar`` is allowed
+* ``from .foo import bar`` is allowed
+* ``from .. import bar`` is not allowed
+* ``from ..foo import bar`` is not allowed
+
 See also
 --------
 

--- a/src/flake8_tidy_imports.py
+++ b/src/flake8_tidy_imports.py
@@ -45,7 +45,10 @@ class ImportChecker:
             action="store",
             default=0,
             parse_from_config=True,
-            help="The maximum number of levels (consecutive dots) that relative imports can use.",
+            help=(
+                "The maximum number of levels (consecutive dots) "
+                + "that relative imports can use."
+            ),
         )
 
     @classmethod

--- a/src/flake8_tidy_imports.py
+++ b/src/flake8_tidy_imports.py
@@ -151,7 +151,9 @@ class ImportChecker:
             and node.level > self.max_relative_import_level
         ):
             if self.max_relative_import_level:
-                level_string = "with level greater than {level} ".format(level=self.max_relative_import_level)
+                level_string = "with level greater than {level} ".format(
+                    level=self.max_relative_import_level
+                )
             else:
                 level_string = ""
             message = self.message_I252.format(level_string=level_string)

--- a/tests/test_flake8_tidy_imports.py
+++ b/tests/test_flake8_tidy_imports.py
@@ -418,7 +418,6 @@ def test_I252_relative_import_3(flake8dir):
     assert result.out_lines == ["./example.py:1:1: I252 Relative imports are banned."]
 
 
-
 def test_I252_relative_import_less_than_max_level(flake8dir):
     flake8dir.make_example_py(
         """
@@ -428,9 +427,9 @@ def test_I252_relative_import_less_than_max_level(flake8dir):
         """
     )
     flake8dir.make_setup_cfg(
-        default_setup_cfg +
-        "ban-relative-imports = true\n" +
-        "max-relative-import-level = 3\n"
+        default_setup_cfg
+        + "ban-relative-imports = true\n"
+        + "max-relative-import-level = 3\n"
     )
     result = flake8dir.run_flake8()
     assert result.out_lines == []
@@ -445,9 +444,9 @@ def test_I252_relative_import_at_max_level(flake8dir):
         """
     )
     flake8dir.make_setup_cfg(
-        default_setup_cfg +
-        "ban-relative-imports = true\n" +
-        "max-relative-import-level = 2\n"
+        default_setup_cfg
+        + "ban-relative-imports = true\n"
+        + "max-relative-import-level = 2\n"
     )
     result = flake8dir.run_flake8()
     assert result.out_lines == []
@@ -462,12 +461,14 @@ def test_I252_relative_import_more_than_max_level(flake8dir):
         """
     )
     flake8dir.make_setup_cfg(
-        default_setup_cfg +
-        "ban-relative-imports = true\n" +
-        "max-relative-import-level = 1\n"
+        default_setup_cfg
+        + "ban-relative-imports = true\n"
+        + "max-relative-import-level = 1\n"
     )
     result = flake8dir.run_flake8()
-    assert result.out_lines == ["./example.py:1:1: I252 Relative imports with level greater than 1 are banned."]
+    assert result.out_lines == [
+        "./example.py:1:1: I252 Relative imports with level greater than 1 are banned."
+    ]
 
 
 def test_I252_relative_import_negative_max_level_is_zero(flake8dir):
@@ -479,13 +480,12 @@ def test_I252_relative_import_negative_max_level_is_zero(flake8dir):
         """
     )
     flake8dir.make_setup_cfg(
-        default_setup_cfg +
-        "ban-relative-imports = true\n" +
-        "max-relative-import-level = -1\n"
+        default_setup_cfg
+        + "ban-relative-imports = true\n"
+        + "max-relative-import-level = -1\n"
     )
     result = flake8dir.run_flake8()
     assert result.out_lines == ["./example.py:1:1: I252 Relative imports are banned."]
-
 
 
 def test_I252_relative_import_commandline(flake8dir):

--- a/tests/test_flake8_tidy_imports.py
+++ b/tests/test_flake8_tidy_imports.py
@@ -418,6 +418,76 @@ def test_I252_relative_import_3(flake8dir):
     assert result.out_lines == ["./example.py:1:1: I252 Relative imports are banned."]
 
 
+
+def test_I252_relative_import_less_than_max_level(flake8dir):
+    flake8dir.make_example_py(
+        """
+        from ..foo import bar
+
+        bar
+        """
+    )
+    flake8dir.make_setup_cfg(
+        default_setup_cfg +
+        "ban-relative-imports = true\n" +
+        "max-relative-import-level = 3\n"
+    )
+    result = flake8dir.run_flake8()
+    assert result.out_lines == []
+
+
+def test_I252_relative_import_at_max_level(flake8dir):
+    flake8dir.make_example_py(
+        """
+        from ..foo import bar
+
+        bar
+        """
+    )
+    flake8dir.make_setup_cfg(
+        default_setup_cfg +
+        "ban-relative-imports = true\n" +
+        "max-relative-import-level = 2\n"
+    )
+    result = flake8dir.run_flake8()
+    assert result.out_lines == []
+
+
+def test_I252_relative_import_more_than_max_level(flake8dir):
+    flake8dir.make_example_py(
+        """
+        from ..foo import bar
+
+        bar
+        """
+    )
+    flake8dir.make_setup_cfg(
+        default_setup_cfg +
+        "ban-relative-imports = true\n" +
+        "max-relative-import-level = 1\n"
+    )
+    result = flake8dir.run_flake8()
+    assert result.out_lines == ["./example.py:1:1: I252 Relative imports with level greater than 1 are banned."]
+
+
+def test_I252_relative_import_negative_max_level_is_zero(flake8dir):
+    flake8dir.make_example_py(
+        """
+        from .foo import bar
+
+        bar
+        """
+    )
+    flake8dir.make_setup_cfg(
+        default_setup_cfg +
+        "ban-relative-imports = true\n" +
+        "max-relative-import-level = -1\n"
+    )
+    result = flake8dir.run_flake8()
+    assert result.out_lines == ["./example.py:1:1: I252 Relative imports are banned."]
+
+
+
 def test_I252_relative_import_commandline(flake8dir):
     flake8dir.make_example_py(
         """


### PR DESCRIPTION
Adds a `--max-relative-import-level` option to allow relative imports up to a certain level.

In our projects, we allow relative imports deeper into the same package, i.e. `from .foo import bar`, but not relative imports up into another package, i.e. `from ..foo import bar`. With this option, we'll be able to use this plugin to enforce that rule.