### PR TITLE
Added 'non-peers' choice for the ban-relative-imports option

### DIFF
--- a/src/flake8_tidy_imports.py
+++ b/src/flake8_tidy_imports.py
@@ -39,9 +39,12 @@ class ImportChecker:
 
         parser.add_option(
             "--ban-relative-imports",
-            action="store_true",
-            default=False,
+            action="store",
+            nargs='?',
+            const='true',
             parse_from_config=True,
+            choices=["", "non-peers", "true"],
+            default="",
             help="Ban relative imports (use absolute imports instead).",
         )
 
@@ -147,10 +150,15 @@ class ImportChecker:
     def rule_I252(
         self, node: ast.AST
     ) -> Generator[Tuple[int, int, str, Type[Any]], None, None]:
+        if self.ban_relative_imports == "non-peers":
+            min_node_level = 1
+        else:
+            min_node_level = 0
+
         if (
             self.ban_relative_imports
             and isinstance(node, ast.ImportFrom)
-            and node.level != 0
+            and node.level > min_node_level
         ):
             yield (node.lineno, node.col_offset, self.message_I252, type(self))
 

--- a/src/flake8_tidy_imports.py
+++ b/src/flake8_tidy_imports.py
@@ -40,8 +40,8 @@ class ImportChecker:
         parser.add_option(
             "--ban-relative-imports",
             action="store",
-            nargs='?',
-            const='true',
+            nargs="?",
+            const="true",
             parse_from_config=True,
             choices=["", "non-peers", "true"],
             default="",

--- a/tests/test_flake8_tidy_imports.py
+++ b/tests/test_flake8_tidy_imports.py
@@ -437,11 +437,11 @@ def test_I252_relative_import_non_peers1(flake8dir):
 
         foo
         """
-
     )
     flake8dir.make_setup_cfg(default_setup_cfg + "ban-relative-imports = non-peers")
     result = flake8dir.run_flake8()
     assert result.out_lines == []
+
 
 def test_I252_relative_import_non_peers2(flake8dir):
     flake8dir.make_example_py(
@@ -450,11 +450,11 @@ def test_I252_relative_import_non_peers2(flake8dir):
 
         bar
         """
-
     )
     flake8dir.make_setup_cfg(default_setup_cfg + "ban-relative-imports = non-peers")
     result = flake8dir.run_flake8()
     assert result.out_lines == []
+
 
 def test_I252_relative_import_non_peers3(flake8dir):
     flake8dir.make_example_py(
@@ -463,11 +463,11 @@ def test_I252_relative_import_non_peers3(flake8dir):
 
         foo
         """
-
     )
     flake8dir.make_setup_cfg(default_setup_cfg + "ban-relative-imports = non-peers")
     result = flake8dir.run_flake8()
     assert result.out_lines == ["./example.py:1:1: I252 Relative imports are banned."]
+
 
 def test_I252_relative_import_non_peers4(flake8dir):
     flake8dir.make_example_py(
@@ -476,11 +476,11 @@ def test_I252_relative_import_non_peers4(flake8dir):
 
         bar
         """
-
     )
     flake8dir.make_setup_cfg(default_setup_cfg + "ban-relative-imports = non-peers")
     result = flake8dir.run_flake8()
     assert result.out_lines == ["./example.py:1:1: I252 Relative imports are banned."]
+
 
 def test_I252_relative_import_non_peers_commandline(flake8dir):
     flake8dir.make_example_py(
@@ -489,7 +489,6 @@ def test_I252_relative_import_non_peers_commandline(flake8dir):
 
         bar
         """
-
     )
     result = flake8dir.run_flake8(["--ban-relative-imports=non-peers"])
     assert result.out_lines == ["./example.py:1:1: I252 Relative imports are banned."]

--- a/tests/test_flake8_tidy_imports.py
+++ b/tests/test_flake8_tidy_imports.py
@@ -428,3 +428,68 @@ def test_I252_relative_import_commandline(flake8dir):
     )
     result = flake8dir.run_flake8(["--ban-relative-imports"])
     assert result.out_lines == ["./example.py:1:1: I252 Relative imports are banned."]
+
+
+def test_I252_relative_import_non_peers1(flake8dir):
+    flake8dir.make_example_py(
+        """
+        from . import foo
+
+        foo
+        """
+
+    )
+    flake8dir.make_setup_cfg(default_setup_cfg + "ban-relative-imports = non-peers")
+    result = flake8dir.run_flake8()
+    assert result.out_lines == []
+
+def test_I252_relative_import_non_peers2(flake8dir):
+    flake8dir.make_example_py(
+        """
+        from .foo import bar
+
+        bar
+        """
+
+    )
+    flake8dir.make_setup_cfg(default_setup_cfg + "ban-relative-imports = non-peers")
+    result = flake8dir.run_flake8()
+    assert result.out_lines == []
+
+def test_I252_relative_import_non_peers3(flake8dir):
+    flake8dir.make_example_py(
+        """
+        from .. import foo
+
+        foo
+        """
+
+    )
+    flake8dir.make_setup_cfg(default_setup_cfg + "ban-relative-imports = non-peers")
+    result = flake8dir.run_flake8()
+    assert result.out_lines == ["./example.py:1:1: I252 Relative imports are banned."]
+
+def test_I252_relative_import_non_peers4(flake8dir):
+    flake8dir.make_example_py(
+        """
+        from ...foo import bar
+
+        bar
+        """
+
+    )
+    flake8dir.make_setup_cfg(default_setup_cfg + "ban-relative-imports = non-peers")
+    result = flake8dir.run_flake8()
+    assert result.out_lines == ["./example.py:1:1: I252 Relative imports are banned."]
+
+def test_I252_relative_import_non_peers_commandline(flake8dir):
+    flake8dir.make_example_py(
+        """
+        from ... import bar
+
+        bar
+        """
+
+    )
+    result = flake8dir.run_flake8(["--ban-relative-imports=non-peers"])
+    assert result.out_lines == ["./example.py:1:1: I252 Relative imports are banned."]


### PR DESCRIPTION
As discussed in #299 this adds a new option to "ban-relative-imports" to allow sibling imports.

Because the option is now a string and not a boolean, I restricted to only three choices : empty, "true" or "non-peers".
Is there a cleaner way to handle this with argparse ? I thought about using the Action, but it might be overkill ...