### PR TITLE
Improve Flake8 config

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -46,6 +46,5 @@ flake8.extension =
     I25 = flake8_tidy_imports:ImportChecker
 
 [flake8]
-max-line-length = 80
-select = E,F,W,B,B950,C,I,TYP
-ignore = E203,E501,W503
+max-line-length = 88
+extend-ignore = E203

--- a/src/flake8_tidy_imports/__init__.py
+++ b/src/flake8_tidy_imports/__init__.py
@@ -188,7 +188,10 @@ class ImportChecker:
         "commands": "removed in Python 3, use subprocess instead",
         "compiler": "removed in Python 3, use ast instead",
         "ConfigParser": "use six.moves.configparser as a drop-in replacement",
-        "contextlib.nested": "use contextlib2.ExitStack or the shim in http://stackoverflow.com/a/39158985/303931",  # noqa:B950
+        "contextlib.nested": (
+            "use contextlib2.ExitStack or the shim in "
+            + "http://stackoverflow.com/a/39158985/303931"
+        ),
         "Cookie": "use six.moves.http_cookies as a drop-in replacement",
         "cookielib": "use six.moves.http_cookiejar as a drop-in replacement",
         "copy_reg": "use six.moves.copyreg as a drop-in replacement",
@@ -200,8 +203,12 @@ class ImportChecker:
         "DocXMLRPCServer": "use six.moves.xmlrpc_server instead",
         "dummy_thread": "use six.moves._dummy_thread as a drop-in replacement",
         "email.MIMEBase": "use six.moves.email_mime_base as a drop-in replacement",
-        "email.MIMEMultipart": "use six.moves.email_mime_multipart as a drop-in replacement",  # noqa:B950
-        "email.MIMENonMultipart": "use six.moves.email_mime_nonmultipart as a drop-in replacement",  # noqa:B950
+        "email.MIMEMultipart": (
+            "use six.moves.email_mime_multipart as a" + " drop-in replacement"
+        ),
+        "email.MIMENonMultipart": (
+            "use six.moves.email_mime_nonmultipart as" + " a drop-in replacement"
+        ),
         "email.MIMEText": "use six.moves.email_mime_text as a drop-in replacement",
         "FileDialog": "use six.moves.tkinter_filedialog as a drop-in replacement",
         "fpformat": "removed in Python 3",
@@ -210,7 +217,10 @@ class ImportChecker:
         "gdbm": "use six.moves.dbm_gnu as a drop-in replacement",
         "htmlentitydefs": "use six.moves.html_entities as a drop-in replacement",
         "htmllib": "use six.moves.html_parser instead",
-        "HTMLParser": "use six.moves.html_parser as a drop-in replacement (except for HTMLParserError)",  # noqa:B950
+        "HTMLParser": (
+            "use six.moves.html_parser as a drop-in replacement"
+            + " (except for HTMLParserError)"
+        ),
         "HTMLParser.HTMLParseError": "removed in Python 3.5+",
         "httplib": "use six.moves.http_client as a drop-in replacement",
         "ihooks": "removed in Python 3",
@@ -272,12 +282,21 @@ class ImportChecker:
         "string.index": "removed in Python 3",
         "string.join": "removed in Python 3",
         "string.joinfields": "removed in Python 3",
-        "string.letters": "moved in Python 3, use string.ascii_letters as a drop-in replacement",  # noqa:B950
+        "string.letters": (
+            "moved in Python 3, use string.ascii_letters as a" + " drop-in replacement"
+        ),
         "string.ljust": "removed in Python 3",
         "string.lower": "removed in Python 3",
-        "string.lowercase": "moved in Python 3, use string.ascii_lowercase as a drop-in replacement",  # noqa:B950
+        "string.lowercase": (
+            "moved in Python 3, use string.ascii_lowercase as"
+            + " a drop-in replacement"
+        ),
         "string.lstrip": "removed in Python 3",
-        "string.maketrans": "moved in Python 3, use bytes.maketrans/bytearray.maketrans or a dict of unicode codepoints to substitutions instead",  # noqa:B950
+        "string.maketrans": (
+            "moved in Python 3, use bytes.maketrans or"
+            + " bytearray.maketrans or a dict of unicode codepoints to"
+            + " substitutions instead"
+        ),
         "string.replace": "removed in Python 3",
         "string.rfind": "removed in Python 3",
         "string.rindex": "removed in Python 3",
@@ -290,18 +309,32 @@ class ImportChecker:
         "string.swapcase": "removed in Python 3",
         "string.translate": "removed in Python 3",
         "string.upper": "removed in Python 3",
-        "string.uppercase": "moved in Python 3, use string.ascii_uppercase as a drop-in replacement",  # noqa:B950
+        "string.uppercase": (
+            "moved in Python 3, use string.ascii_uppercase as a drop-in replacement"
+        ),
         "string.zfill": "removed in Python 3",
         "StringIO": "moved in Python 3, use io.StringIO or io.BytesIO instead",
         "stringold": "removed in Python 3",
         "sunaudio": "removed in Python 3",
         "sv": "removed in Python 3",
-        "tarfile.S_IFBLK": "moved in Python 3, use stat.S_IFBLK as a drop-in replacement",  # noqa:B950
-        "tarfile.S_IFCHR": "moved in Python 3, use stat.S_IFCHR as a drop-in replacement",  # noqa:B950
-        "tarfile.S_IFDIR": "moved in Python 3, use stat.S_IFDIR as a drop-in replacement",  # noqa:B950
-        "tarfile.S_IFIFO": "moved in Python 3, use stat.S_IFIFO as a drop-in replacement",  # noqa:B950
-        "tarfile.S_IFLNK": "moved in Python 3, use stat.S_IFLNK as a drop-in replacement",  # noqa:B950
-        "tarfile.S_IFREG": "moved in Python 3, use stat.S_IFREG as a drop-in replacement",  # noqa:B950
+        "tarfile.S_IFBLK": (
+            "moved in Python 3, use stat.S_IFBLK as a drop-in replacement"
+        ),
+        "tarfile.S_IFCHR": (
+            "moved in Python 3, use stat.S_IFCHR as a drop-in replacement"
+        ),
+        "tarfile.S_IFDIR": (
+            "moved in Python 3, use stat.S_IFDIR as a drop-in replacement"
+        ),
+        "tarfile.S_IFIFO": (
+            "moved in Python 3, use stat.S_IFIFO as a drop-in replacement"
+        ),
+        "tarfile.S_IFLNK": (
+            "moved in Python 3, use stat.S_IFLNK as a drop-in replacement"
+        ),
+        "tarfile.S_IFREG": (
+            "moved in Python 3, use stat.S_IFREG as a drop-in replacement"
+        ),
         "test.test_support": "moved in Python 3, use test.support instead",
         "test.testall": "removed in Python 3",
         "thread": "moved in Python 3, use six.moves._thread as a drop-in replacement",
@@ -316,7 +349,9 @@ class ImportChecker:
         "tkFont": "use six.moves.tkinter_font as a drop-in replacement",
         "Tkinter": "use six.moves.tkinter as a drop-in replacement",
         "tkMessageBox": "use six.moves.tkinter_messagebox as a drop-in replacement",
-        "tkSimpleDialog": "use six.moves.tkinter_tksimpledialog as a drop-in replacement",  # noqa:B950
+        "tkSimpleDialog": (
+            "use six.moves.tkinter_tksimpledialog as a drop-in replacement"
+        ),
         "toaiff": "removed in Python 3",
         "ttk": "use six.moves.tkinter_ttk as a drop-in replacement",
         "types.BooleanType": "moved in Python 3, use bool as a drop-in replacement",
@@ -326,7 +361,9 @@ class ImportChecker:
         "types.DictionaryType": "removed in Python 3",
         "types.DictProxyType": "removed in Python 3",
         "types.DictType": "moved in Python 3, use dict as a drop-in replacement",
-        "types.EllipsisType": "moved in Python 3, use type(Ellipsis) as a drop-in replacement",  # noqa:B950
+        "types.EllipsisType": (
+            "moved in Python 3, use type(Ellipsis) as a drop-in replacement"
+        ),
         "types.FileType": "removed in Python 3",
         "types.FloatType": "moved in Python 3, use float as a drop-in replacement",
         "types.InstanceType": "removed in Python 3",
@@ -337,76 +374,184 @@ class ImportChecker:
         "types.NotImplementedType": "removed in Python 3",
         "types.ObjectType": "removed in Python 3",
         "types.SliceType": "removed in Python 3",
-        "types.StringType": "use six.binary_types or six.text_types, depending on context, instead",  # noqa:B950
+        "types.StringType": (
+            "use six.binary_types or six.text_types, depending on context, instead"
+        ),
         "types.StringTypes": "use six.string_types as a drop-in replacement",
         "types.TupleType": "moved in Python 3, use tuple as a drop-in replacement",
         "types.TypeType": "use six.class_types as a drop-in replacement",
         "types.UnboundMethodType": "removed in Python 3",
         "types.UnicodeType": "use six.text_type as a drop-in replacement",
         "types.XRangeType": "removed in Python 3",
-        "urllib.ContentTooShortError": "use six.moves.urllib.error.ContentTooShortError as a drop-in replacement",  # noqa:B950
-        "urllib.FancyURLopener": "use six.moves.urllib.request.FancyURLopener as a drop-in replacement",  # noqa:B950
-        "urllib.getproxies": "use six.moves.urllib.request.getproxies as a drop-in replacement",  # noqa:B950
-        "urllib.pathname2url": "use six.moves.urllib.request.pathname2url as a drop-in replacement",  # noqa:B950
-        "urllib.proxy_bypass": "use six.moves.urllib.request.proxy_bypass as a drop-in replacement",  # noqa:B950
+        "urllib.ContentTooShortError": (
+            "use six.moves.urllib.error.ContentTooShortError as a drop-in replacement"
+        ),
+        "urllib.FancyURLopener": (
+            "use six.moves.urllib.request.FancyURLopener as a drop-in replacement"
+        ),
+        "urllib.getproxies": (
+            "use six.moves.urllib.request.getproxies as a drop-in replacement"
+        ),
+        "urllib.pathname2url": (
+            "use six.moves.urllib.request.pathname2url as a drop-in replacement"
+        ),
+        "urllib.proxy_bypass": (
+            "use six.moves.urllib.request.proxy_bypass as a drop-in replacement"
+        ),
         "urllib.quote": "use six.moves.urllib.parse.quote as a drop-in replacement",
-        "urllib.quote_plus": "use six.moves.urllib.parse.quote_plus as a drop-in replacement",  # noqa:B950
+        "urllib.quote_plus": (
+            "use six.moves.urllib.parse.quote_plus as a drop-in replacement"
+        ),
         "urllib.splitattr": "moved in Python 3, use urllib.parse.splitattr instead",
         "urllib.splithost": "moved in Python 3, use urllib.parse.splithost instead",
         "urllib.splitnport": "moved in Python 3, use urllib.parse.splitnport instead",
         "urllib.splitpasswd": "moved in Python 3, use urllib.parse.splitpasswd instead",
         "urllib.splitport": "moved in Python 3, use urllib.parse.splitport instead",
-        "urllib.splitquery": "use six.moves.urllib.parse.splitquery as a drop-in replacement",  # noqa:B950
-        "urllib.splittag": "use six.moves.urllib.parse.splittag as a drop-in replacement",  # noqa:B950
+        "urllib.splitquery": (
+            "use six.moves.urllib.parse.splitquery as a drop-in replacement"
+        ),
+        "urllib.splittag": (
+            "use six.moves.urllib.parse.splittag as a drop-in replacement"
+        ),
         "urllib.splittype": "moved in Python 3, use urllib.parse.splittype instead",
-        "urllib.splituser": "use six.moves.urllib.parse.splituser as a drop-in replacement",  # noqa:B950
+        "urllib.splituser": (
+            "use six.moves.urllib.parse.splituser as a drop-in replacement"
+        ),
         "urllib.splitvalue": "moved in Python 3, use urllib.parse.splitvalue instead",
         "urllib.unquote": "use six.moves.urllib.parse.unquote as a drop-in replacement",
-        "urllib.unquote_plus": "use six.moves.urllib.parse.unquote_plus as a drop-in replacement",  # noqa:B950
-        "urllib.url2pathname": "use six.moves.urllib.request.url2pathname as a drop-in replacement",  # noqa:B950
-        "urllib.urlcleanup": "use six.moves.urllib.request.urlcleanup as a drop-in replacement",  # noqa:B950
-        "urllib.urlencode": "use six.moves.urllib.parse.urlencode as a drop-in replacement",  # noqa:B950
-        "urllib.URLopener": "use six.moves.urllib.request.URLopener as a drop-in replacement",  # noqa:B950
-        "urllib.urlretrieve": "use six.moves.urllib.request.urlretrieve as a drop-in replacement",  # noqa:B950
+        "urllib.unquote_plus": (
+            "use six.moves.urllib.parse.unquote_plus as a drop-in replacement"
+        ),
+        "urllib.url2pathname": (
+            "use six.moves.urllib.request.url2pathname as a drop-in replacement"
+        ),
+        "urllib.urlcleanup": (
+            "use six.moves.urllib.request.urlcleanup as a drop-in replacement"
+        ),
+        "urllib.urlencode": (
+            "use six.moves.urllib.parse.urlencode as a drop-in replacement"
+        ),
+        "urllib.URLopener": (
+            "use six.moves.urllib.request.URLopener as a drop-in replacement"
+        ),
+        "urllib.urlretrieve": (
+            "use six.moves.urllib.request.urlretrieve as a drop-in replacement"
+        ),
         "urllib2": "use six.moves.urllib instead",
-        "urllib2.AbstractBasicAuthHandler": "use six.moves.urllib.request.AbstractBasicAuthHandler as a drop-in replacement",  # noqa:B950
-        "urllib2.AbstractDigestAuthHandler": "use six.moves.urllib.request.AbstractDigestAuthHandler as a drop-in replacement",  # noqa:B950
-        "urllib2.BaseHandler": "use six.moves.urllib.request.BaseHandler as a drop-in replacement",  # noqa:B950
-        "urllib2.build_opener": "use six.moves.urllib.request.build_opener as a drop-in replacement",  # noqa:B950
-        "urllib2.CacheFTPHandler": "use six.moves.urllib.request.CacheFTPHandler as a drop-in replacement",  # noqa:B950
-        "urllib2.FileHandler": "use six.moves.urllib.request.FileHandler as a drop-in replacement",  # noqa:B950
-        "urllib2.FTPHandler": "use six.moves.urllib.request.FTPHandler as a drop-in replacement",  # noqa:B950
-        "urllib2.HTTPBasicAuthHandler": "use six.moves.urllib.request.HTTPBasicAuthHandler as a drop-in replacement",  # noqa:B950
-        "urllib2.HTTPCookieProcessor": "use six.moves.urllib.request.HTTPCookieProcessor as a drop-in replacement",  # noqa:B950
-        "urllib2.HTTPDefaultErrorHandler": "use six.moves.urllib.request.HTTPDefaultErrorHandler as a drop-in replacement",  # noqa:B950
-        "urllib2.HTTPDigestAuthHandler": "use six.moves.urllib.request.HTTPDigestAuthHandler as a drop-in replacement",  # noqa:B950
-        "urllib2.HTTPError": "use six.moves.urllib.error.HTTPError as a drop-in replacement",  # noqa:B950
-        "urllib2.HTTPErrorProcessor": "use six.moves.urllib.request.HTTPErrorProcessor as a drop-in replacement",  # noqa:B950
-        "urllib2.HTTPHandler": "use six.moves.urllib.request.HTTPHandler as a drop-in replacement",  # noqa:B950
-        "urllib2.HTTPPasswordMgr": "use six.moves.urllib.request.HTTPPasswordMgr as a drop-in replacement",  # noqa:B950
-        "urllib2.HTTPPasswordMgrWithDefaultRealm": "use six.moves.urllib.request.HTTPPasswordMgrWithDefaultRealm as a drop-in replacement",  # noqa:B950
-        "urllib2.HTTPRedirectHandler": "use six.moves.urllib.request.HTTPRedirectHandler as a drop-in replacement",  # noqa:B950
-        "urllib2.HTTPSHandler": "use six.moves.urllib.request.HTTPSHandler as a drop-in replacement",  # noqa:B950
-        "urllib2.install_opener": "use six.moves.urllib.request.install_opener as a drop-in replacement",  # noqa:B950
-        "urllib2.OpenerDirector": "use six.moves.urllib.request.OpenerDirector as a drop-in replacement",  # noqa:B950
-        "urllib2.ProxyBasicAuthHandler": "use six.moves.urllib.request.ProxyBasicAuthHandler as a drop-in replacement",  # noqa:B950
-        "urllib2.ProxyDigestAuthHandler": "use six.moves.urllib.request.ProxyDigestAuthHandler as a drop-in replacement",  # noqa:B950
-        "urllib2.ProxyHandler": "use six.moves.urllib.request.ProxyHandler as a drop-in replacement",  # noqa:B950
+        "urllib2.AbstractBasicAuthHandler": (
+            "use six.moves.urllib.request.AbstractBasicAuthHandler as a"
+            + " drop-in replacement"
+        ),
+        "urllib2.AbstractDigestAuthHandler": (
+            "use six.moves.urllib.request.AbstractDigestAuthHandler as a"
+            + " drop-in replacement"
+        ),
+        "urllib2.BaseHandler": (
+            "use six.moves.urllib.request.BaseHandler as a drop-in replacement"
+        ),
+        "urllib2.build_opener": (
+            "use six.moves.urllib.request.build_opener as a drop-in replacement"
+        ),
+        "urllib2.CacheFTPHandler": (
+            "use six.moves.urllib.request.CacheFTPHandler as a drop-in replacement"
+        ),
+        "urllib2.FileHandler": (
+            "use six.moves.urllib.request.FileHandler as a drop-in replacement"
+        ),
+        "urllib2.FTPHandler": (
+            "use six.moves.urllib.request.FTPHandler as a drop-in replacement"
+        ),
+        "urllib2.HTTPBasicAuthHandler": (
+            "use six.moves.urllib.request.HTTPBasicAuthHandler as a drop-in replacement"
+        ),
+        "urllib2.HTTPCookieProcessor": (
+            "use six.moves.urllib.request.HTTPCookieProcessor as a drop-in replacement"
+        ),
+        "urllib2.HTTPDefaultErrorHandler": (
+            "use six.moves.urllib.request.HTTPDefaultErrorHandler as a drop-in"
+            + " replacement"
+        ),
+        "urllib2.HTTPDigestAuthHandler": (
+            "use six.moves.urllib.request.HTTPDigestAuthHandler as a drop-in"
+            + " replacement"
+        ),
+        "urllib2.HTTPError": (
+            "use six.moves.urllib.error.HTTPError as a drop-in replacement"
+        ),
+        "urllib2.HTTPErrorProcessor": (
+            "use six.moves.urllib.request.HTTPErrorProcessor as a drop-in replacement"
+        ),
+        "urllib2.HTTPHandler": (
+            "use six.moves.urllib.request.HTTPHandler as a drop-in replacement"
+        ),
+        "urllib2.HTTPPasswordMgr": (
+            "use six.moves.urllib.request.HTTPPasswordMgr as a drop-in replacement"
+        ),
+        "urllib2.HTTPPasswordMgrWithDefaultRealm": (
+            "use six.moves.urllib.request.HTTPPasswordMgrWithDefaultRealm as"
+            + " a drop-in replacement"
+        ),
+        "urllib2.HTTPRedirectHandler": (
+            "use six.moves.urllib.request.HTTPRedirectHandler as a drop-in replacement"
+        ),
+        "urllib2.HTTPSHandler": (
+            "use six.moves.urllib.request.HTTPSHandler as a drop-in replacement"
+        ),
+        "urllib2.install_opener": (
+            "use six.moves.urllib.request.install_opener as a drop-in replacement"
+        ),
+        "urllib2.OpenerDirector": (
+            "use six.moves.urllib.request.OpenerDirector as a drop-in replacement"
+        ),
+        "urllib2.ProxyBasicAuthHandler": (
+            "use six.moves.urllib.request.ProxyBasicAuthHandler as a drop-in"
+            + " replacement"
+        ),
+        "urllib2.ProxyDigestAuthHandler": (
+            "use six.moves.urllib.request.ProxyDigestAuthHandler as a drop-in"
+            + " replacement"
+        ),
+        "urllib2.ProxyHandler": (
+            "use six.moves.urllib.request.ProxyHandler as a drop-in replacement"
+        ),
         "urllib2.quote": "use six.moves.urllib.parse.quote as a drop-in replacement",
-        "urllib2.Request": "use six.moves.urllib.request.Request as a drop-in replacement",  # noqa:B950
-        "urllib2.UnknownHandler": "use six.moves.urllib.request.UnknownHandler as a drop-in replacement",  # noqa:B950
-        "urllib2.unquote": "use six.moves.urllib.parse.unquote as a drop-in replacement",  # noqa:B950
-        "urllib2.URLError": "use six.moves.urllib.error.URLError as a drop-in replacement",  # noqa:B950
-        "urllib2.urlopen": "use six.moves.urllib.request.urlopen as a drop-in replacement",  # noqa:B950
+        "urllib2.Request": (
+            "use six.moves.urllib.request.Request as a drop-in replacement"
+        ),
+        "urllib2.UnknownHandler": (
+            "use six.moves.urllib.request.UnknownHandler as a drop-in replacement"
+        ),
+        "urllib2.unquote": (
+            "use six.moves.urllib.parse.unquote as a drop-in replacement"
+        ),
+        "urllib2.URLError": (
+            "use six.moves.urllib.error.URLError as a drop-in replacement"
+        ),
+        "urllib2.urlopen": (
+            "use six.moves.urllib.request.urlopen as a drop-in replacement"
+        ),
         "urlparse": "use six.moves.urllib.parse as a drop-in replacement",
         "urlparse.scheme_chars": "moved in Python 3, use urllib.parse.scheme_chars",
         "user": "removed in Python 3",
-        "UserDict": "moved in Python 3, use dict or collections.UserDict/collections.MutableMapping instead",  # noqa:B950
-        "UserDict.UserDict": "moved in Python 3, use six.moves.UserDict as a drop-in replacement",  # noqa:B950
-        "UserDict.UserDictMixin": "moved in Python 3, use collections.MutableMapping instead",  # noqa:B950
-        "UserList": "moved in Python 3, use list or collections.UserList/collections.MutableSequence instead",  # noqa:B950
+        "UserDict": (
+            "moved in Python 3, use dict or collections.UserDict or"
+            + " collections.MutableMapping instead"
+        ),
+        "UserDict.UserDict": (
+            "moved in Python 3, use six.moves.UserDict as a drop-in replacement"
+        ),
+        "UserDict.UserDictMixin": (
+            "moved in Python 3, use collections.MutableMapping instead"
+        ),
+        "UserList": (
+            "moved in Python 3, use list or collections.UserList or"
+            + " collections.MutableSequence instead"
+        ),
         "UserList.UserList": "use six.moves.UserList as a drop-in replacement",
-        "UserString": "moved in Python 3, use six.text_type, six.binary_type or collections.UserString instead",  # noqa:B950
+        "UserString": (
+            "moved in Python 3, use six.text_type, six.binary_type or"
+            + " collections.UserString instead"
+        ),
         "UserString.UserString": "use six.moves.UserString as a drop-in replacement",
         "xmlrpclib": "use six.moves.xmlrpc_client as a drop-in replacement",
     }


### PR DESCRIPTION
Use only Black compat options. Removing 'select' declaration means that plugin error codes are selected by default.
